### PR TITLE
Copyright updates

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2021 Oracle and/or its affiliates and others.
+    Copyright (c) 1997, 2022 Oracle and/or its affiliates and others.
     All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -297,7 +297,7 @@
                             <header><![CDATA[<br>Jakarta Servlet API v${project.version}]]></header>
                             <bottom><![CDATA[
 Comments to: <a href="mailto:servlet-dev@eclipse.org">servlet-dev@eclipse.org</a>.<br>
-Copyright &#169; 2019, 2021 Eclipse Foundation. All rights reserved.<br>
+Copyright &#169; 2019, 2022 Eclipse Foundation. All rights reserved.<br>
 Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
                             </bottom>
                             <docfilessubdirs>true</docfilessubdirs>

--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -5,7 +5,7 @@
 :sectnums!:
 == Jakarta Servlet Specification, Version {spec-version}
 
-Copyright (c) 2021 Contributors to the Eclipse Foundation.
+Copyright (c) 2022 Contributors to the Eclipse Foundation.
 
 Eclipse is a registered trademark of the Eclipse Foundation. Jakarta
 is a trademark of the Eclipse Foundation. Oracle and Java are
@@ -8602,6 +8602,9 @@ align with changes in the Jakarta Pages 3.1 specification.
 
 Clarify the Javadoc for `ServletRequest.isAsyncStarted()` to align it with the
 specification text.
+
+Update the Javadoc to clarify the scheduling implications when `ServletInputStream.isReady()`
+or `ServletOutputStream.isReady()` return `false`.
 
 === Compatibility with Jakarta Servlet Specification Version 4.0
 Jakarta Servlet version 5.0 is only a change of namespaces

--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -8560,6 +8560,11 @@ link:https://github.com/eclipse-ee4j/servlet-api/issues/175[Issue 175]::
 Provide generic attribute support to cookies, including session cookies, to
 provide support for additional attributes such as the `SameSite` attribute.
 
+link:https://github.com/eclipse-ee4j/servlet-api/issues/201[Issue 201]::
+Add a `module-info.java` to support using the Servlet API in a modular
+environment as per the Java module system and the Jakarta EE 10 
+link:https://github.com/jakartaee/specification-committee/blob/master/names.adoc[recommendations].
+
 link:https://github.com/eclipse-ee4j/servlet-api/issues/225[Issue 225]::
 Deprecated wrapped response handling in the `doHead` method in favour of container implementation of `HEAD` method behavior.
 
@@ -8591,11 +8596,6 @@ link:https://github.com/eclipse-ee4j/servlet-api/issues/418[Issue 418]::
 Remove API classes and methods that were deprecated in Servlet 5.0 and earlier.
 This includes removing the `SingleThreadModel` and `HttpSessionContext`
 interfaces and the `HttpUtils` class as well as various deprecated methods.
-
-link:https://github.com/eclipse-ee4j/servlet-api/issues/201[Issue 201]::
-Add a `module-info.java` to support using the Servlet API in a modular
-environment as per the Java module system and the Jakarta EE 10 
-link:https://github.com/jakartaee/specification-committee/blob/master/names.adoc[recommendations].
 
 Add a new method `getErrorOnELNotFound()` to `JspPropertyGroupDescriptor` to
 align with changes in the Jakarta Pages 3.1 specification.


### PR DESCRIPTION
Checking everything after the schema update I noticed there was a Javadoc change in 2022 but the Javadoc was copyrighted 2021. I've fixed that.

That got me looking at the spec document where I noticed the Javadoc change wasn't listed in the changelog so I fixed that too. That triggered a copyright date change for the spec doc - which has the benefit of aligning the copyright dates for the spec doc and the Java doc,