### PR TITLE
Update version to 6.1

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>jakarta.servlet</groupId>
     <artifactId>jakarta.servlet-api</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
 
     <name>Jakarta Servlet</name>
     <url>https://projects.eclipse.org/projects/ee4j.servlet</url>
@@ -216,13 +216,13 @@
                         <supportedProjectType>jar</supportedProjectType>
                     </supportedProjectTypes>
                     <instructions>
-                        <Bundle-Version>6.0.0</Bundle-Version>
+                        <Bundle-Version>6.1.0</Bundle-Version>
                         <Bundle-SymbolicName>jakarta.servlet-api</Bundle-SymbolicName>
                         <Bundle-Description>
-                            Jakarta Servlet 6.0
+                            Jakarta Servlet 6.1
                         </Bundle-Description>
                         <Extension-Name>jakarta.servlet</Extension-Name>
-                        <Specification-Version>6.0</Specification-Version>
+                        <Specification-Version>6.1</Specification-Version>
                         <Specification-Vendor>Eclipse Foundation</Specification-Vendor>
                         <Implementation-Version>${project.version}</Implementation-Version>
                         <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2022 Oracle and/or its affiliates and others.
+    All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,7 +29,7 @@
 
     <groupId>jakarta.servlet</groupId>
     <artifactId>servlet-parent</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Servlet Parent</name>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation.
+    Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,11 +22,11 @@
     <parent>
         <groupId>jakarta.servlet</groupId>
         <artifactId>servlet-parent</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>servlet-spec</artifactId>
-    <version>6.0-SNAPSHOT</version>
+    <version>6.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Servlet Specification</name>

--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -1,6 +1,6 @@
 :xrefstyle: full
-:spec-version: 6.0
-:spec-version-underscore: 6_0
+:spec-version: 6.1
+:spec-version-underscore: 6_1
 
 :sectnums!:
 == Jakarta Servlet Specification, Version {spec-version}


### PR DESCRIPTION
This assumes we won't be making any breaking changes / significant new features in the next release. If there are plans for that, we'll need to move to 7.0