### PR TITLE
Fix #59 - Add 'query_string' attribute to error dispatches

### DIFF
--- a/api/src/main/java/jakarta/servlet/RequestDispatcher.java
+++ b/api/src/main/java/jakarta/servlet/RequestDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2022 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -161,6 +161,14 @@ public interface RequestDispatcher {
      * @since Servlet 3.0
      */
     public static final String ERROR_REQUEST_URI = "jakarta.servlet.error.request_uri";
+
+    /**
+     * The name of the request attribute under which the query string for request whose processing caused the error is
+     * propagated during an error dispatch
+     *
+     * @since Servlet 6.1
+     */
+    static final String ERROR_QUERY_STRING = "jakarta.servlet.error.query_string";
 
     /**
      * The name of the request attribute under which the name of the servlet in which the error occurred is propagated

--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -5515,15 +5515,20 @@ a `RequestDispatcher.forward` to the error resource had been performed.
 |`jakarta.servlet.error.request_uri`
 |`java.lang.String`
 
+|`jakarta.servlet.error.query_string`
+|`java.lang.String`
+
 |`jakarta.servlet.error.servlet_name`
 |`java.lang.String`
 |===
 
 These attributes allow the servlet to generate
 specialized content depending on the status code, the exception type,
-the error message, the exception object propagated, and the URI of the
+the error message, the exception object propagated, the URI of the
 request processed by the servlet in which the error occurred (as
-determined by the `getRequestURI` call), and the logical name of the
+determined by the `getRequestURI` call), the query string of the
+request processed by the servlet in which the error occurred (as
+determined by the `getQueryString` call) and the logical name of the
 servlet in which the error occurred.
 
 With the introduction of the exception object


### PR DESCRIPTION
Fixes #59 

Mainly a note to self - need to update ErrorData in pages if this is merged.