### PR TITLE
Fix Javadoc issue highlighted by #473

### DIFF
--- a/api/src/main/java/jakarta/servlet/http/HttpServletRequest.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletRequest.java
@@ -693,7 +693,7 @@ public interface HttpServletRequest extends ServletRequest {
      * no trailer fields.
      * </ol>
      *
-     * @implSpec The default implementation returns false.
+     * @implSpec The default implementation returns {@code true}.
      *
      * @return a boolean whether trailer fields are ready to read
      *


### PR DESCRIPTION
Align Javadoc with current behaviour.

The default current behaviour is consistent with an implementation that does not implement trailer fields. isTrailerFieldsReady() returns true and a subsequent call to getTrailerFields() returns an empty Map.