### PR TITLE
Fix #275 - containers can use relative URLS for redirects

### DIFF
--- a/api/src/main/java/jakarta/servlet/http/HttpServletResponse.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletResponse.java
@@ -147,12 +147,21 @@ public interface HttpServletResponse extends ServletResponse {
     /**
      * Sends a temporary redirect response to the client using the specified redirect location URL and clears the buffer.
      * The buffer will be replaced with the data set by this method. Calling this method sets the status code to
-     * {@link #SC_FOUND} 302 (Found). This method can accept relative URLs;the servlet container must convert the relative
-     * URL to an absolute URL before sending the response to the client. If the location is relative without a leading '/'
-     * the container interprets it as relative to the current request URI. If the location is relative with a leading '/'
-     * the container interprets it as relative to the servlet container root. If the location is relative with two leading
-     * '/' the container interprets it as a network-path reference (see <a href="http://www.ietf.org/rfc/rfc3986.txt"> RFC
-     * 3986: Uniform Resource Identifier (URI): Generic Syntax</a>, section 4.2 &quot;Relative Reference&quot;).
+     * {@link #SC_FOUND} 302 (Found).
+     * <p>
+     * This method accepts both relative and absolute URLs. Absolute URLs passed to this method are used as provided as the
+     * redirect location URL. Relative URLs are converted to absolute URLs unless a container specific feature/option is
+     * provided that controls whether relative URLs passed to this method are converted to absolute URLs or used as provided
+     * for the redirect location URL. If converting a relative URL to an absolute URL then:
+     * <ul>
+     * <li>If the location is relative without a leading '/' the container interprets it as relative to the current request
+     * URI.</li>
+     * <li>If the location is relative with a leading '/' the container interprets it as relative to the servlet container
+     * root.</li>
+     * <li>If the location is relative with two leading '/' the container interprets it as a network-path reference (see
+     * <a href="http://www.ietf.org/rfc/rfc3986.txt"> RFC 3986: Uniform Resource Identifier (URI): Generic Syntax</a>,
+     * section 4.2 &quot;Relative Reference&quot;).</li>
+     * </ul>
      *
      * <p>
      * If the response has already been committed, this method throws an IllegalStateException. After using this method, the

--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -2512,13 +2512,14 @@ The following convenience methods exist in the
 
 * `sendError`
 
-The `sendRedirect` method will set the
-appropriate headers and content body to redirect the client to a
-different URL. It is legal to call this method with a relative URL path,
-however the underlying container must translate the relative path to a
-fully qualified URL for transmission back to the client. If a partial
-URL is given and, for whatever reason, cannot be converted into a valid
-URL, then this method must throw an `IllegalArgumentException`.
+The `sendRedirect` method will set the appropriate headers and content body to
+redirect the client to a different URL.
+It is legal to call this method with a relative URL path.
+The underlying container may provide an option to use the relative URL path as
+provided but if no such option is provided it must translate the relative path
+to a fully qualified URL for transmission back to the client.
+If a partial URL is given and, for whatever reason, cannot be converted into a
+valid URL, then this method must throw an `IllegalArgumentException`.
 
 The `sendError` method will set the
 appropriate headers and content body for an error message to return to
@@ -8558,6 +8559,10 @@ Clarify that Servlet containers are required to support HTTPS.
 link:https://github.com/eclipse-ee4j/servlet-api/issues/164[Issue 164]::
 Clarify Javadoc for `ServletResponse` and `HttpServletResponse` methods that are
 NO-OPs once the response has been committed.
+
+link:https://github.com/eclipse-ee4j/servlet-api/issues/275[Issue 275]::
+Containers may provide an option to send redirects using a location header with
+a relative URL.
 
 link:https://github.com/eclipse-ee4j/servlet-api/issues/325[Issue 325]::
 Clarify the behaviour of `getDateHeader()` and `getIntHeader()` when multiple


### PR DESCRIPTION
Doesn't mandate any new behaviour, just opens the door for containers that want to to use relative redirects while remaining specification compliant.