### PR TITLE
Fix issue-484 Add read/write via ByteBuffer

### DIFF
--- a/api/src/main/java/jakarta/servlet/ServletInputStream.java
+++ b/api/src/main/java/jakarta/servlet/ServletInputStream.java
@@ -20,9 +20,11 @@ package jakarta.servlet;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Objects;
 
 /**
- * 
+ *
  * Provides an input stream for reading binary data from a client request, including an efficient <code>readLine</code>
  * method for reading data one line at a time. With some protocols, such as HTTP POST and PUT, a
  * <code>ServletInputStream</code> object can be used to read data sent from the client.
@@ -51,14 +53,75 @@ public abstract class ServletInputStream extends InputStream {
     }
 
     /**
+     * Reads from the input stream into the given buffer.
+     * <p>
+     * If the input stream is in non-blocking mode, before each invocation of this method {@link isReady()} must be called
+     * and must return {@code true} or the {@link ReadListener#onDataAvailable()} call back must indicate that data is
+     * available to read else an {@link IllegalStateException} must be thrown.
+     * <p>
+     * Otherwise, if this method is called when {@code buffer} has no space remaining, the method returns {@code 0}
+     * immediately and {@code buffer} is unchanged.
+     * <p>
+     * If the input stream is in blocking mode and {@code buffer} has space remaining, this method blocks until at least one
+     * byte has been read, end of stream is reached or an exception is thrown.
+     * <p>
+     * Returns the number of bytes read or {@code -1} if the end of stream is reached without reading any data.
+     * <p>
+     * When the method returns, and if data has been read, the buffer's position will be unchanged from the value when
+     * passed to this method and the limit will be the position incremented by the number of bytes read.
+     * <p>
+     * Subclasses are strongly encouraged to override this method and provide a more efficient implementation.
      *
+     * @param buffer The buffer into which the data is read.
+     *
+     * @return The number of bytes read or {@code -1} if the end of the stream has been reached.
+     *
+     * @exception IllegalStateException If the input stream is in non-blocking mode and this method is called without first
+     * calling {@link #isReady()} and that method has returned {@code true} or {@link ReadListener#onDataAvailable()} has
+     * not signalled that data is available to read.
+     * 
+     * @exception IOException If data cannot be read for any reason other than the end of stream being reached, the input
+     * stream has been closed or if some other I/O error occurs.
+     * 
+     * @exception NullPointerException If buffer is null.
+     * 
+     * @since Servlet 6.1
+     */
+    public int read(ByteBuffer buffer) throws IOException {
+        Objects.requireNonNull(buffer);
+
+        if (!isReady()) {
+            throw new IllegalStateException();
+        }
+
+        if (buffer.remaining() == 0) {
+            return 0;
+        }
+
+        byte[] b = new byte[buffer.remaining()];
+
+        int result = read(b);
+        if (result == -1) {
+            return -1;
+        }
+
+        int position = buffer.position();
+
+        buffer.put(b, 0, result);
+
+        buffer.position(position);
+        buffer.limit(position + result);
+
+        return result;
+    }
+
+    /**
      * Reads the input stream, one line at a time. Starting at an offset, reads bytes into an array, until it reads a
      * certain number of bytes or reaches a newline character, which it reads into the array as well.
-     *
      * <p>
-     * This method returns -1 if it reaches the end of the input stream before reading the maximum number of bytes.
-     *
-     *
+     * This method returns {@code -1} if it reaches the end of the input stream before reading the maximum number of bytes.
+     * <p>
+     * This method may only be used when the input stream is in blocking mode.
      *
      * @param b an array of bytes into which data is read
      *
@@ -68,8 +131,9 @@ public abstract class ServletInputStream extends InputStream {
      *
      * @return an integer specifying the actual number of bytes read, or -1 if the end of the stream is reached
      *
+     * @exception IllegalStateException If this method is called when the input stream is in non-blocking mode.
+     * 
      * @exception IOException if an input or output exception has occurred
-     *
      */
     public int readLine(byte[] b, int off, int len) throws IOException {
 
@@ -99,14 +163,19 @@ public abstract class ServletInputStream extends InputStream {
     public abstract boolean isFinished();
 
     /**
-     * Returns true if data can be read without blocking else returns false.
+     * Returns {@code true} if it is allowable to call a {@code read()} method. In blocking mode, this method will always
+     * return {@code true}, but a subsequent call to a {@code read()} method may block awaiting data. In non-blocking mode
+     * this method may return {@code false}, in which case it is illegal to call a {@code read()} method and an
+     * {@link IllegalStateException} MUST be thrown. When {@link ReadListener#onDataAvailable()} is called, a call to this
+     * method that returned {@code true} is implicit.
      * <p>
-     * If this method returns false and a {@link ReadListener} has been set via {@link #setReadListener(ReadListener)}, then
-     * the container will subsequently invoke {@link ReadListener#onDataAvailable()} (or
-     * {@link ReadListener#onAllDataRead()}) once data (or EOF) has become available. Other than the initial call,
-     * {@link ReadListener#onDataAvailable()} will only be called if and only if this method is called and returns false.
+     * If this method returns {@code false} and a {@link ReadListener} has been set via
+     * {@link #setReadListener(ReadListener)}, then the container will subsequently invoke
+     * {@link ReadListener#onDataAvailable()} (or {@link ReadListener#onAllDataRead()}) once data (or EOF) has become
+     * available. Other than the initial call, {@link ReadListener#onDataAvailable()} will only be called if and only if
+     * this method is called and returns false.
      *
-     * @return <code>true</code> if data can be obtained without blocking, otherwise returns <code>false</code>.
+     * @return {@code true} if data can be obtained without blocking, otherwise returns {@code false}.
      * @see ReadListener
      * @since Servlet 3.1
      */
@@ -126,7 +195,43 @@ public abstract class ServletInputStream extends InputStream {
      * @throws NullPointerException if readListener is null
      *
      * @since Servlet 3.1
-     * 
+     *
      */
     public abstract void setReadListener(ReadListener readListener);
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method may only be used when the input stream is in blocking mode.
+     * 
+     * @exception IllegalStateException If this method is called when the input stream is in non-blocking mode.
+     */
+    @Override
+    public byte[] readAllBytes() throws IOException {
+        return super.readAllBytes();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method may only be used when the input stream is in blocking mode.
+     * 
+     * @exception IllegalStateException If this method is called when the input stream is in non-blocking mode.
+     */
+    @Override
+    public byte[] readNBytes(int len) throws IOException {
+        return super.readNBytes(len);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method may only be used when the input stream is in blocking mode.
+     * 
+     * @exception IllegalStateException If this method is called when the input stream is in non-blocking mode.
+     */
+    @Override
+    public int readNBytes(byte[] b, int off, int len) throws IOException {
+        return super.readNBytes(b, off, len);
+    }
 }

--- a/api/src/main/java/jakarta/servlet/ServletOutputStream.java
+++ b/api/src/main/java/jakarta/servlet/ServletOutputStream.java
@@ -21,7 +21,9 @@ package jakarta.servlet;
 import java.io.CharConversionException;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.text.MessageFormat;
+import java.util.Objects;
 import java.util.ResourceBundle;
 
 /**
@@ -49,6 +51,57 @@ public abstract class ServletOutputStream extends OutputStream {
      *
      */
     protected ServletOutputStream() {
+    }
+
+    /**
+     * Writes from the given buffer to the output stream.
+     * <p>
+     * If the output steam is in non-blocking mode, before each invocation of this method {@link isReady()} must be called
+     * and must return {@code true} or the {@link WriteListener#onWritePossible()} call back must indicate that data may be
+     * written else an {@link IllegalStateException} must be thrown.
+     * <p>
+     * Otherwise, if this method is called when {@code buffer} has no data remaining, the method returns immediately and
+     * {@code buffer} is unchanged.
+     * <p>
+     * If the output stream is in non-blocking mode, neither the position, limit nor content of the buffer passed to this
+     * method may be modified until a subsequent call to {@link #isReady()} returns true or the
+     * {@link WriteListener#onWritePossible()} call back indicates data may be written again. At this point the buffer's
+     * limit will be unchanged from the value when passed to this method and the position will be the same as the limit.
+     * <p>
+     * If the output stream is in blocking mode and {@code buffer} has space remaining, this method blocks until all the
+     * remaining data in the buffer has been written. When the method returns, and if data has been written, the buffer's
+     * limit will be unchanged from the value when passed to this method and the position will be the same as the limit.
+     * <p>
+     * Subclasses are strongly encouraged to override this method and provide a more efficient implementation.
+     *
+     * @param buffer The buffer from which the data is written.
+     *
+     * @exception IllegalStateException If the output stream is in non-blocking mode and this method is called without first
+     * calling {@link #isReady()} and that method has returned {@code true} or {@link WriteListener#onWritePossible()} has
+     * not signalled that data may be written.
+     * 
+     * @exception IOException If the output stream has been closed or if some other I/O error occurs.
+     *
+     * @exception NullPointerException If buffer is null.
+     * 
+     * @since Servlet 6.1
+     */
+    public void write(ByteBuffer buffer) throws IOException {
+        Objects.requireNonNull(buffer);
+
+        if (!isReady()) {
+            throw new IllegalStateException();
+        }
+
+        if (buffer.remaining() == 0) {
+            return;
+        }
+
+        byte[] b = new byte[buffer.remaining()];
+
+        buffer.get(b);
+
+        write(b);
     }
 
     /**
@@ -272,14 +325,19 @@ public abstract class ServletOutputStream extends OutputStream {
     }
 
     /**
-     * Returns true if data can be written without blocking else returns false.
+     * Returns {@code true} if it is allowable to call any method that may write data (e.g. {@code write()}, {@code print()}
+     * or {@code flush}). In blocking mode, this method will always return {@code true}, but a subsequent call to a method
+     * that writes data may block. In non-blocking mode this method may return {@code false}, in which case it is illegal to
+     * call a method that writes data and an {@link IllegalStateException} MUST be thrown. When
+     * {@link WriteListener#onWritePossible()} is called, a call to this method that returned {@code true} is implicit.
      * <p>
-     * If this method returns false and a {@link WriteListener} has been set with {@link #setWriteListener(WriteListener)},
-     * then container will subsequently invoke {@link WriteListener#onWritePossible()} once a write operation becomes
-     * possible without blocking. Other than the initial call, {@link WriteListener#onWritePossible()} will only be called
-     * if and only if this method is called and returns false.
+     * If this method returns {@code false} and a {@link WriteListener} has been set via
+     * {@link #setWriteListener(WriteListener)}, then container will subsequently invoke
+     * {@link WriteListener#onWritePossible()} once a write operation becomes possible without blocking. Other than the
+     * initial call, {@link WriteListener#onWritePossible()} will only be called if and only if this method is called and
+     * returns false.
      *
-     * @return <code>true</code> if data can be written without blocking, otherwise returns <code>false</code>.
+     * @return {@code true} if data can be written without blocking, otherwise returns {@code false}.
      * @see WriteListener
      * @since Servlet 3.1
      */
@@ -304,4 +362,16 @@ public abstract class ServletOutputStream extends OutputStream {
      */
     public abstract void setWriteListener(WriteListener writeListener);
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * If this method is called when the output stream is in non-blocking mode, it will immediately return with the stream
+     * effectively closed, even if the stream contains buffered data that is yet to be written to client. The container will
+     * write this data out in the background. If this process fails the {@link WriteListener#onError(Throwable)} method will
+     * be invoked as normal.
+     */
+    @Override
+    public void close() throws IOException {
+        super.close();
+    }
 }

--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -8577,6 +8577,9 @@ link:https://github.com/eclipse-ee4j/servlet-api/issues/473[Issue 473]::
 The Javadoc for `HttpServletRequest.isTrailerFieldsReady()` has been corrected
 to correctly describe the default implementation.
 
+link:https://github.com/eclipse-ee4j/servlet-api/issues/484[Issue 484]::
+Add ByteBuffer support to `ServletInputStream` and `ServletOutputStream`.
+
 === Changes Since Jakarta Servlet 5.0
 
 The minimum Java version has been increased to Java 11.


### PR DESCRIPTION
Could be applied as-is but more likely to be a starting point for discussion.

The default implementations could be more efficient but I opted for clarity over efficiency given that containers should be overriding these methods anyway.

One obvious question - to we want to add scatter/gather read/write?