### PR TITLE
Fix #273 - clarify behaviour around non-blocking writes

### DIFF
--- a/api/src/main/java/jakarta/servlet/AsyncContext.java
+++ b/api/src/main/java/jakarta/servlet/AsyncContext.java
@@ -154,12 +154,22 @@ public interface AsyncContext {
      *
      * <p>
      * This method returns immediately after passing the request and response objects to a container managed thread, on
-     * which the dispatch operation will be performed. If this method is called before the container-initiated dispatch that
-     * called <tt>startAsync</tt> has returned to the container, the dispatch operation will be delayed until after the
-     * container-initiated dispatch has returned to the container. If the output stream is in non-blocking mode when this
-     * method is called, the output stream will be closed as described by {@code ServletOutputStream#close} and the dispatch
-     * operation will be delayed until after the non-blocking write has completed.
-     *
+     * which the dispatch operation will be performed. If this method is called during a container-initiated dispatch, the
+     * dispatch operation will be delayed until after the container-initiated dispatch has returned to the container. <br>
+     * Note: Container initiated dispatches include calls to:
+     * <ul>
+     * <li>{@link Servlet#service(ServletRequest, ServletResponse)} where {@link ServletRequest#startAsync()} or
+     * {@link ServletRequest#startAsync(ServletRequest, ServletResponse)} is called</li>
+     * <li>{@link ReadListener#onDataAvailable()}</li>
+     * <li>{@link ReadListener#onAllDataRead()}</li>
+     * <li>{@link WriteListener#onWritePossible()}</li>
+     * </ul>
+     * 
+     * <p>
+     * If the output stream is in non-blocking mode when this method is called, the output stream will be closed as
+     * described by {@code ServletOutputStream#close} and the dispatch operation will be delayed until after any in progress
+     * non-blocking write has completed.
+     * 
      * <p>
      * The dispatcher type of the request is set to <tt>DispatcherType.ASYNC</tt>. Unlike
      * {@link RequestDispatcher#forward(ServletRequest, ServletResponse) forward dispatches}, the response buffer and
@@ -275,15 +285,23 @@ public interface AsyncContext {
      * <p>
      * It is legal to call this method any time after a call to {@link ServletRequest#startAsync()} or
      * {@link ServletRequest#startAsync(ServletRequest, ServletResponse)}, and before a call to one of the <tt>dispatch</tt>
-     * methods of this class. If this method is called before the container-initiated dispatch that called
-     * <tt>startAsync</tt> has returned to the container, then the call will not take effect (and any invocations of
-     * {@link AsyncListener#onComplete(AsyncEvent)} will be delayed) until after the container-initiated dispatch has
-     * returned to the container.
+     * methods of this class. If this method is called during a container-initiated dispatch, then the call will not take
+     * effect (including required listener invocations) until after the container-initiated dispatch has returned to the
+     * container. <br>
+     * Note: Container initiated dispatches include calls to:
+     * <ul>
+     * <li>{@link Servlet#service(ServletRequest, ServletResponse)} where {@link ServletRequest#startAsync()} or
+     * {@link ServletRequest#startAsync(ServletRequest, ServletResponse)} is called</li>
+     * <li>{@link ReadListener#onDataAvailable()}</li>
+     * <li>{@link ReadListener#onAllDataRead()}</li>
+     * <li>{@link WriteListener#onWritePossible()}</li>
+     * </ul>
      *
      * <p>
      * If the output stream is in non-blocking mode when this method is called, the output stream will be closed as
      * described by {@code ServletOutputStream#close} and this call to complete will not take effect (and any invocations of
-     * {@link AsyncListener#onComplete(AsyncEvent)} will be delayed) until after the non-blocking write has completed.
+     * {@link AsyncListener#onComplete(AsyncEvent)} will be delayed) until after any in progress non-blocking write has
+     * completed.
      */
     public void complete();
 

--- a/api/src/main/java/jakarta/servlet/AsyncContext.java
+++ b/api/src/main/java/jakarta/servlet/AsyncContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -156,7 +156,9 @@ public interface AsyncContext {
      * This method returns immediately after passing the request and response objects to a container managed thread, on
      * which the dispatch operation will be performed. If this method is called before the container-initiated dispatch that
      * called <tt>startAsync</tt> has returned to the container, the dispatch operation will be delayed until after the
-     * container-initiated dispatch has returned to the container.
+     * container-initiated dispatch has returned to the container. If the output stream is in non-blocking mode when this
+     * method is called, the output stream will be closed as described by {@code ServletOutputStream#close} and the dispatch
+     * operation will be delayed until after the non-blocking write has completed.
      *
      * <p>
      * The dispatcher type of the request is set to <tt>DispatcherType.ASYNC</tt>. Unlike
@@ -277,6 +279,11 @@ public interface AsyncContext {
      * <tt>startAsync</tt> has returned to the container, then the call will not take effect (and any invocations of
      * {@link AsyncListener#onComplete(AsyncEvent)} will be delayed) until after the container-initiated dispatch has
      * returned to the container.
+     *
+     * <p>
+     * If the output stream is in non-blocking mode when this method is called, the output stream will be closed as
+     * described by {@code ServletOutputStream#close} and this call to complete will not take effect (and any invocations of
+     * {@link AsyncListener#onComplete(AsyncEvent)} will be delayed) until after the non-blocking write has completed.
      */
     public void complete();
 

--- a/api/src/main/java/jakarta/servlet/ReadListener.java
+++ b/api/src/main/java/jakarta/servlet/ReadListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -34,14 +34,16 @@ public interface ReadListener extends EventListener {
      * When an instance of the <code>ReadListener</code> is registered with a {@link ServletInputStream}, this method will
      * be invoked by the container the first time when it is possible to read data. Subsequently the container will invoke
      * this method if and only if the {@link jakarta.servlet.ServletInputStream#isReady()} method has been called and has
-     * returned a value of <code>false</code> <em>and</em> data has subsequently become available to read.
+     * returned a value of <code>false</code>, data has subsequently become available to read and any previous call to this
+     * method has returned to the container.
      *
      * @throws IOException if an I/O related error has occurred during processing
      */
     public void onDataAvailable() throws IOException;
 
     /**
-     * Invoked when all data for the current request has been read.
+     * Invoked when all data for the current request has been read and any previous call to {@link #onDataAvailable()} has
+     * returned to the container.
      *
      * @throws IOException if an I/O related error has occurred during processing
      */

--- a/api/src/main/java/jakarta/servlet/ServletOutputStream.java
+++ b/api/src/main/java/jakarta/servlet/ServletOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2023 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -325,10 +325,10 @@ public abstract class ServletOutputStream extends OutputStream {
     }
 
     /**
-     * Returns {@code true} if it is allowable to call any method that may write data (e.g. {@code write()}, {@code print()}
-     * or {@code flush}). In blocking mode, this method will always return {@code true}, but a subsequent call to a method
-     * that writes data may block. In non-blocking mode this method may return {@code false}, in which case it is illegal to
-     * call a method that writes data and an {@link IllegalStateException} MUST be thrown. When
+     * Returns {@code true} if it is allowable to call any method that may write data (i.e. {@code write()}, {@code print()}
+     * {@code println()} or {@code flush}). In blocking mode, this method will always return {@code true}, but a subsequent
+     * call to a method that writes data may block. In non-blocking mode this method may return {@code false}, in which case
+     * it is illegal to call a method that writes data and an {@link IllegalStateException} MUST be thrown. When
      * {@link WriteListener#onWritePossible()} is called, a call to this method that returned {@code true} is implicit.
      * <p>
      * If this method returns {@code false} and a {@link WriteListener} has been set via

--- a/api/src/main/java/jakarta/servlet/WriteListener.java
+++ b/api/src/main/java/jakarta/servlet/WriteListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -32,7 +32,8 @@ public interface WriteListener extends EventListener {
      * When an instance of the WriteListener is registered with a {@link ServletOutputStream}, this method will be invoked
      * by the container the first time when it is possible to write data. Subsequently the container will invoke this method
      * if and only if the {@link jakarta.servlet.ServletOutputStream#isReady()} method has been called and has returned a
-     * value of <code>false</code> and a write operation has subsequently become possible.
+     * value of <code>false</code>. a write operation has subsequently become possible and any previous call to this method
+     * has returned to the container.
      *
      * @throws IOException if an I/O related error has occurred during processing
      */

--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -2486,7 +2486,7 @@ This method returns
 `true` if a write to the `ServletOutputStream` will succeed, otherwise
 it will return `false`. If this method returns `true`, a write
 operation can be performed on the `ServletOutputStream`. If no further
-data can be written to the `ServletOutputStream`. then this method will
+data can be written to the `ServletOutputStream` then this method will
 return `false` till the underlying data is flushed at which point the
 container will invoke the `onWritePossible` method of the
 `WriteListener.` A subsequent call to this method will return `true`.
@@ -8559,6 +8559,12 @@ Clarify that Servlet containers are required to support HTTPS.
 link:https://github.com/eclipse-ee4j/servlet-api/issues/164[Issue 164]::
 Clarify Javadoc for `ServletResponse` and `HttpServletResponse` methods that are
 NO-OPs once the response has been committed.
+
+link:https://github.com/eclipse-ee4j/servlet-api/issues/273[Issue 273]::
+Clarify the meaning of "write operation" in the Javadoc for
+`ServletOutputStream.isReady()` and, in particular, that this does not include
+`ServletOutputStream.close()`, `AsyncContext.complete()` nor any of the
+`AsyncContext.dispatch()` methods.
 
 link:https://github.com/eclipse-ee4j/servlet-api/issues/275[Issue 275]::
 Containers may provide an option to send redirects using a location header with

--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -8564,7 +8564,8 @@ link:https://github.com/eclipse-ee4j/servlet-api/issues/273[Issue 273]::
 Clarify the meaning of "write operation" in the Javadoc for
 `ServletOutputStream.isReady()` and, in particular, that this does not include
 `ServletOutputStream.close()`, `AsyncContext.complete()` nor any of the
-`AsyncContext.dispatch()` methods.
+`AsyncContext.dispatch()` methods. Further clarify the Javadoc regarding the
+serialization of asynchronous dispatches.
 
 link:https://github.com/eclipse-ee4j/servlet-api/issues/275[Issue 275]::
 Containers may provide an option to send redirects using a location header with


### PR DESCRIPTION
This turned out to be a much smaller change than I was expecting - primarily because applications still need to call `complete()` or `dispatch()` after they call `ServletOutputSream.close()`.