### PR TITLE
Do not fail when tests when cross context not supported (as it is not mandatory per spec)

### DIFF
--- a/tck/README.md
+++ b/tck/README.md
@@ -1,0 +1,45 @@
+# Jakarta Servlet
+
+This repository contains the code for Jakarta Servle TCK
+
+About Jakarta Servlet TCK
+-------------------------
+Jakarta Servlet TCK defines a server-side API for handling HTTP requests and is based on Junit5 and Arquillian.
+
+Building
+--------
+Prerequisites:
+
+* JDK 11+
+* Maven 3.9.0+
+
+Run the build: 
+
+`mvn install`
+
+Running TCK 
+------------
+You need to configure your Apache Maven build to run tests from the tck artifacts.
+This will be achieved by adding a dependency within your surefire configuration
+```xml
+    <dependencies>
+      <dependency>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>tck-runtime</artifactId>
+      </dependency>
+    </dependencies>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-surefire-plugin</artifactId>
+      <version>${surefire.version}</version>
+      <configuration>
+        <dependenciesToScan>
+          <dependenciesToScan>jakarta.servlet:tck-runtime</dependenciesToScan>
+        </dependenciesToScan>
+        <systemProperties>
+          <!-- if the servlet container doesn't support optional cross context -->  
+          <servlet.tck.support.crossContext>false</servlet.tck.support.crossContext>
+        </systemProperties>          
+      </configuration>
+    </plugin>
+```

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet/dispatchtest/DispatchTestServlet.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet/dispatchtest/DispatchTestServlet.java
@@ -21,6 +21,7 @@ package servlet.tck.api.jakarta_servlet.dispatchtest;
 
 import java.io.IOException;
 
+import jakarta.servlet.ServletContext;
 import servlet.tck.common.servlets.GenericTCKServlet;
 
 import jakarta.servlet.AsyncContext;
@@ -156,9 +157,10 @@ public class DispatchTestServlet extends GenericTCKServlet {
     AsyncContext ac = request.startAsync();
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
-    ac.dispatch(
-        request.getServletContext().getContext(getDispatcher1ContextRoot()),
-        "/DispatchTests10?testname=dispatchTest10");
+    ServletContext context = request.getServletContext().getContext(getDispatcher1ContextRoot());
+    if (context!=null) {
+      ac.dispatch(context,"/DispatchTests10?testname=dispatchTest10");
+    }
     response.getWriter()
         .println("dispatch return=" + System.currentTimeMillis());
   }
@@ -176,9 +178,10 @@ public class DispatchTestServlet extends GenericTCKServlet {
     AsyncContext ac = request.startAsync(request, response);
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
-    ac.dispatch(
-        request.getServletContext().getContext(getDispatcher1ContextRoot()),
-        "/DispatchTests10?testname=dispatchTest10");
+    ServletContext servletContext = request.getServletContext().getContext(getDispatcher1ContextRoot());
+    if(servletContext!=null){
+      ac.dispatch(servletContext, "/DispatchTests10?testname=dispatchTest10");
+    }
     response.getWriter()
         .println("dispatch return=" + System.currentTimeMillis());
   }
@@ -584,9 +587,10 @@ public class DispatchTestServlet extends GenericTCKServlet {
     AsyncContext ac = request.startAsync();
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
-    ac.dispatch(
-        request.getServletContext().getContext(getDispatcher1ContextRoot()),
-        "/DispatchTests11?testname=dispatchTest11");
+    ServletContext servletContext = request.getServletContext().getContext(getDispatcher1ContextRoot());
+    if(servletContext!=null) {
+      ac.dispatch(servletContext, "/DispatchTests11?testname=dispatchTest11");
+    }
     response.getWriter()
         .println("dispatch return=" + System.currentTimeMillis());
   }
@@ -684,9 +688,10 @@ public class DispatchTestServlet extends GenericTCKServlet {
     AsyncContext ac = request.startAsync(request, response);
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
-    ac.dispatch(
-        request.getServletContext().getContext(getDispatcher1ContextRoot()),
-        "/DispatchTests16?testname=dispatchTest16");
+    ServletContext servletContext = request.getServletContext().getContext(getDispatcher1ContextRoot());
+    if(servletContext!=null) {
+      ac.dispatch(servletContext, "/DispatchTests16?testname=dispatchTest16");
+    }
     response.getWriter()
         .println("dispatch return=" + System.currentTimeMillis());
   }

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet/dispatchtest/DispatchTestServlet.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet/dispatchtest/DispatchTestServlet.java
@@ -27,6 +27,7 @@ import servlet.tck.common.servlets.GenericTCKServlet;
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
+import servlet.tck.common.util.ServletTestUtil;
 
 public class DispatchTestServlet extends GenericTCKServlet {
 
@@ -158,8 +159,10 @@ public class DispatchTestServlet extends GenericTCKServlet {
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
     ServletContext context = request.getServletContext().getContext(getDispatcher1ContextRoot());
-    if (context!=null) {
+    if (context!=null || ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
       ac.dispatch(context,"/DispatchTests10?testname=dispatchTest10");
+    } else {
+      ac.complete();
     }
     response.getWriter()
         .println("dispatch return=" + System.currentTimeMillis());
@@ -179,8 +182,10 @@ public class DispatchTestServlet extends GenericTCKServlet {
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
     ServletContext servletContext = request.getServletContext().getContext(getDispatcher1ContextRoot());
-    if(servletContext!=null){
+    if(servletContext!=null || ServletTestUtil.SUPPORT_CROSS_CONTEXT ) {
       ac.dispatch(servletContext, "/DispatchTests10?testname=dispatchTest10");
+    } else {
+      ac.complete();
     }
     response.getWriter()
         .println("dispatch return=" + System.currentTimeMillis());
@@ -588,8 +593,10 @@ public class DispatchTestServlet extends GenericTCKServlet {
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
     ServletContext servletContext = request.getServletContext().getContext(getDispatcher1ContextRoot());
-    if(servletContext!=null) {
+    if(servletContext!=null|| ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
       ac.dispatch(servletContext, "/DispatchTests11?testname=dispatchTest11");
+    } else {
+      ac.complete();
     }
     response.getWriter()
         .println("dispatch return=" + System.currentTimeMillis());
@@ -608,9 +615,12 @@ public class DispatchTestServlet extends GenericTCKServlet {
     AsyncContext ac = request.startAsync(request, response);
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
-    ac.dispatch(
-        request.getServletContext().getContext(getDispatcher1ContextRoot()),
-        "/DispatchTests12?testname=dispatchTest12");
+    ServletContext servletContext = request.getServletContext().getContext(getDispatcher1ContextRoot());
+    if(servletContext!=null|| ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      ac.dispatch(servletContext, "/DispatchTests12?testname=dispatchTest12");
+    } else {
+      ac.complete();
+    }
     response.getWriter()
         .println("dispatch return=" + System.currentTimeMillis());
   }
@@ -628,9 +638,12 @@ public class DispatchTestServlet extends GenericTCKServlet {
     AsyncContext ac = request.startAsync();
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
-    ac.dispatch(
-        request.getServletContext().getContext(getDispatcher1ContextRoot()),
-        "/DispatchTests13?testname=dispatchTest13");
+    ServletContext servletContext = request.getServletContext().getContext(getDispatcher1ContextRoot());
+    if(servletContext!=null|| ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      ac.dispatch(servletContext, "/DispatchTests13?testname=dispatchTest13");
+    } else {
+      ac.complete();
+    }
     response.getWriter()
         .println("dispatch return=" + System.currentTimeMillis());
   }
@@ -648,9 +661,12 @@ public class DispatchTestServlet extends GenericTCKServlet {
     AsyncContext ac = request.startAsync(request, response);
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
-    ac.dispatch(
-        request.getServletContext().getContext(getDispatcher1ContextRoot()),
-        "/DispatchTests14?testname=dispatchTest14");
+    ServletContext servletContext = request.getServletContext().getContext(getDispatcher1ContextRoot());
+    if(servletContext!=null|| ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      ac.dispatch(servletContext, "/DispatchTests14?testname=dispatchTest14");
+    } else {
+      ac.complete();
+    }
     response.getWriter()
         .println("dispatch return=" + System.currentTimeMillis());
   }
@@ -668,9 +684,12 @@ public class DispatchTestServlet extends GenericTCKServlet {
     AsyncContext ac = request.startAsync();
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
-    ac.dispatch(
-        request.getServletContext().getContext(getDispatcher1ContextRoot()),
-        "/DispatchTests15?testname=dispatchTest15");
+    ServletContext servletContext = request.getServletContext().getContext(getDispatcher1ContextRoot());
+    if(servletContext!=null|| ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      ac.dispatch(servletContext, "/DispatchTests15?testname=dispatchTest15");
+    } else {
+      ac.complete();
+    }
     response.getWriter()
         .println("dispatch return=" + System.currentTimeMillis());
   }
@@ -689,8 +708,10 @@ public class DispatchTestServlet extends GenericTCKServlet {
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
     ServletContext servletContext = request.getServletContext().getContext(getDispatcher1ContextRoot());
-    if(servletContext!=null) {
+    if(servletContext!=null || ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
       ac.dispatch(servletContext, "/DispatchTests16?testname=dispatchTest16");
+    } else {
+      ac.complete();
     }
     response.getWriter()
         .println("dispatch return=" + System.currentTimeMillis());
@@ -852,22 +873,25 @@ public class DispatchTestServlet extends GenericTCKServlet {
     AsyncContext ac = request.startAsync();
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
-    ac.dispatch(
-        request.getServletContext().getContext(getDispatcher1ContextRoot()),
-        "/DispatchTests10?testname=dispatchTest10");
-    response.getWriter()
-        .println("dispatch return=" + System.currentTimeMillis());
-
-    try {
-      response.getWriter().println("dispatch again");
-      ac.dispatch(
-          request.getServletContext()
-              .getContext(getDispatcher1ContextRoot()),
-          "/DispatchTests19?testname=dispatchTest19");
-    } catch (IllegalStateException ex) {
-      response.getWriter().println("dispatch() called again");
+    ServletContext servletContext = request.getServletContext().getContext(getDispatcher1ContextRoot());
+    if(servletContext!=null || ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      ac.dispatch(servletContext, "/DispatchTests10?testname=dispatchTest10");
       response.getWriter()
-          .println("Expected IllegalStateException thrown" + ex.getMessage());
+              .println("dispatch return=" + System.currentTimeMillis());
+
+      try {
+        response.getWriter().println("dispatch again");
+        ac.dispatch(
+                request.getServletContext()
+                        .getContext(getDispatcher1ContextRoot()),
+                "/DispatchTests19?testname=dispatchTest19");
+      } catch (IllegalStateException ex) {
+        response.getWriter().println("dispatch() called again");
+        response.getWriter()
+                .println("Expected IllegalStateException thrown" + ex.getMessage());
+      }
+    } else {
+      ac.complete();
     }
   }
 
@@ -884,22 +908,25 @@ public class DispatchTestServlet extends GenericTCKServlet {
     AsyncContext ac = request.startAsync(request, response);
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
-    ac.dispatch(
-        request.getServletContext().getContext(getDispatcher1ContextRoot()),
-        "/DispatchTests10?testname=dispatchTest10");
-    response.getWriter()
-        .println("dispatch return=" + System.currentTimeMillis());
-
-    try {
-      response.getWriter().println("dispatch again");
-      ac.dispatch(
-          request.getServletContext()
-              .getContext(getDispatcher1ContextRoot()),
-          "/DispatchTests19?testname=dispatchTest19");
-    } catch (IllegalStateException ex) {
-      response.getWriter().println("dispatch() called again");
+    ServletContext servletContext = request.getServletContext().getContext(getDispatcher1ContextRoot());
+    if(servletContext!=null || ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      ac.dispatch(servletContext, "/DispatchTests10?testname=dispatchTest10");
       response.getWriter()
-          .println("Expected IllegalStateException thrown" + ex.getMessage());
+              .println("dispatch return=" + System.currentTimeMillis());
+
+      try {
+        response.getWriter().println("dispatch again");
+        ac.dispatch(
+                request.getServletContext()
+                        .getContext(getDispatcher1ContextRoot()),
+                "/DispatchTests19?testname=dispatchTest19");
+      } catch (IllegalStateException ex) {
+        response.getWriter().println("dispatch() called again");
+        response.getWriter()
+                .println("Expected IllegalStateException thrown" + ex.getMessage());
+      }
+    } else {
+      ac.complete();
     }
   }
 
@@ -917,19 +944,22 @@ public class DispatchTestServlet extends GenericTCKServlet {
     AsyncContext ac = request.startAsync();
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
-    ac.dispatch(
-        request.getServletContext().getContext(getDispatcher1ContextRoot()),
-        "/DispatchTests10?testname=dispatchTest10");
-    response.getWriter()
-        .println("dispatch return=" + System.currentTimeMillis());
-
-    try {
-      response.getWriter().println("dispatch again");
-      ac.dispatch("/DispatchTests?testname=dispatchTest");
-    } catch (IllegalStateException ex) {
-      response.getWriter().println("dispatch(URI) called again");
+    ServletContext servletContext = request.getServletContext().getContext(getDispatcher1ContextRoot());
+    if(servletContext!=null || ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      ac.dispatch(servletContext, "/DispatchTests10?testname=dispatchTest10");
       response.getWriter()
-          .println("Expected IllegalStateException thrown" + ex.getMessage());
+              .println("dispatch return=" + System.currentTimeMillis());
+
+      try {
+        response.getWriter().println("dispatch again");
+        ac.dispatch("/DispatchTests?testname=dispatchTest");
+      } catch (IllegalStateException ex) {
+        response.getWriter().println("dispatch(URI) called again");
+        response.getWriter()
+                .println("Expected IllegalStateException thrown" + ex.getMessage());
+      }
+    } else {
+      ac.complete();
     }
   }
 
@@ -947,19 +977,22 @@ public class DispatchTestServlet extends GenericTCKServlet {
     AsyncContext ac = request.startAsync(request, response);
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
-    ac.dispatch(
-        request.getServletContext().getContext(getDispatcher1ContextRoot()),
-        "/DispatchTests10?testname=dispatchTest10");
-    response.getWriter()
-        .println("dispatch return=" + System.currentTimeMillis());
-
-    try {
-      response.getWriter().println("dispatch again");
-      ac.dispatch("/DispatchTests?testname=dispatchTest");
-    } catch (IllegalStateException ex) {
-      response.getWriter().println("dispatch(URI) called again");
+    ServletContext servletContext = request.getServletContext().getContext(getDispatcher1ContextRoot());
+    if(servletContext!=null || ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      ac.dispatch(servletContext, "/DispatchTests10?testname=dispatchTest10");
       response.getWriter()
-          .println("Expected IllegalStateException thrown" + ex.getMessage());
+              .println("dispatch return=" + System.currentTimeMillis());
+
+      try {
+        response.getWriter().println("dispatch again");
+        ac.dispatch("/DispatchTests?testname=dispatchTest");
+      } catch (IllegalStateException ex) {
+        response.getWriter().println("dispatch(URI) called again");
+        response.getWriter()
+                .println("Expected IllegalStateException thrown" + ex.getMessage());
+      }
+    } else {
+      ac.complete();
     }
   }
 
@@ -1092,9 +1125,12 @@ public class DispatchTestServlet extends GenericTCKServlet {
     AsyncContext ac = request.startAsync();
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
-    ac.dispatch(
-        request.getServletContext().getContext(getDispatcher1ContextRoot()),
-        "/DispatchTests10?testname=dispatchTest10");
+    ServletContext servletContext = request.getServletContext().getContext(getDispatcher1ContextRoot());
+    if(servletContext!=null || ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      ac.dispatch(servletContext, "/DispatchTests10?testname=dispatchTest10");
+    } else {
+      ac.complete();
+    }
     response.getWriter()
         .println("dispatch return=" + System.currentTimeMillis());
   }
@@ -1115,9 +1151,12 @@ public class DispatchTestServlet extends GenericTCKServlet {
     AsyncContext ac = request.startAsync(request, response);
     response.getWriter()
         .println("Before dispatch=" + System.currentTimeMillis());
-    ac.dispatch(
-        request.getServletContext().getContext(getDispatcher1ContextRoot()),
-        "/DispatchTests10?testname=dispatchTest10");
+    ServletContext servletContext = request.getServletContext().getContext(getDispatcher1ContextRoot());
+    if(servletContext!=null || ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      ac.dispatch(servletContext, "/DispatchTests10?testname=dispatchTest10");
+    } else {
+      ac.complete();
+    }
     response.getWriter()
         .println("dispatch return=" + System.currentTimeMillis());
   }

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet/dispatchtest/DispatchTests.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet/dispatchtest/DispatchTests.java
@@ -28,6 +28,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import servlet.tck.common.util.ServletTestUtil;
 
 import java.net.URL;
 
@@ -205,12 +206,19 @@ public class DispatchTests extends AbstractTckTest {
   @Test
   public void dispatchReturnTest4() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "dispatchReturnTest4");
-    TEST_PROPS.get().setProperty(SEARCH_STRING,
-        "ASYNC_NOT_STARTED_dispatchReturnTest4|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
-            + "Before dispatch|" + "dispatch return|" + "After dispatch|"
-            + "ASYNC_STARTED_dispatchTest10|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=ASYNC");
+    if (ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_dispatchReturnTest4|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|" + "dispatch return|" + "After dispatch|"
+                      + "ASYNC_STARTED_dispatchTest10|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=ASYNC");
+    } else {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,"ASYNC_NOT_STARTED_dispatchReturnTest4|"
+              + "IsAsyncSupported=true|"
+              + "IsAsyncStarted=false|"
+              + "DispatcherType=REQUEST");
+    }
     invoke();
   }
 
@@ -233,12 +241,19 @@ public class DispatchTests extends AbstractTckTest {
   @Test
   public void dispatchReturnTest5() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "dispatchReturnTest5");
-    TEST_PROPS.get().setProperty(SEARCH_STRING,
-        "ASYNC_NOT_STARTED_dispatchReturnTest5|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
-            + "Before dispatch|" + "dispatch return|" + "After dispatch|"
-            + "ASYNC_STARTED_dispatchTest10|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=ASYNC");
+    if (ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_dispatchReturnTest5|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|" + "dispatch return|" + "After dispatch|"
+                      + "ASYNC_STARTED_dispatchTest10|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=ASYNC");
+    } else {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,"ASYNC_NOT_STARTED_dispatchReturnTest5|"
+              + "IsAsyncSupported=true|"
+              + "IsAsyncStarted=false|"
+              + "DispatcherType=REQUEST");
+    }
     invoke();
   }
 
@@ -656,16 +671,23 @@ public class DispatchTests extends AbstractTckTest {
   @Test
   public void startAsyncAgainTest12() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "startAsyncAgainTest12");
-    TEST_PROPS.get().setProperty(SEARCH_STRING,
-        "ASYNC_NOT_STARTED_startAsyncAgainTest12|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
-            + "Before dispatch|" + "dispatch return|" + "After dispatch|"
-            + "ASYNC_STARTED_dispatchTest11|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=ASYNC|"
-            + "Before second dispatch|" + "second dispatch return|"
-            + "After dispatch|" + "ASYNC_STARTED_dispatchTest|"
-            + "IsAsyncSupported=true|" + "IsAsyncStarted=false|"
-            + "DispatcherType=ASYNC");
+    if(ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_startAsyncAgainTest12|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|" + "dispatch return|" + "After dispatch|"
+                      + "ASYNC_STARTED_dispatchTest11|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=ASYNC|"
+                      + "Before second dispatch|" + "second dispatch return|"
+                      + "After dispatch|" + "ASYNC_STARTED_dispatchTest|"
+                      + "IsAsyncSupported=true|" + "IsAsyncStarted=false|"
+                      + "DispatcherType=ASYNC");
+    } else {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_startAsyncAgainTest12|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|");
+    }
     invoke();
   }
 
@@ -689,16 +711,23 @@ public class DispatchTests extends AbstractTckTest {
   @Test
   public void startAsyncAgainTest13() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "startAsyncAgainTest13");
-    TEST_PROPS.get().setProperty(SEARCH_STRING,
-        "ASYNC_NOT_STARTED_startAsyncAgainTest13|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
-            + "Before dispatch|" + "dispatch return|" + "After dispatch|"
-            + "ASYNC_STARTED_dispatchTest12|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=ASYNC|"
-            + "Before second dispatch|" + "second dispatch return|"
-            + "After dispatch|" + "ASYNC_STARTED_dispatchTest|"
-            + "IsAsyncSupported=true|" + "IsAsyncStarted=false|"
-            + "DispatcherType=ASYNC");
+    if(ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_startAsyncAgainTest13|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|" + "dispatch return|" + "After dispatch|"
+                      + "ASYNC_STARTED_dispatchTest12|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=ASYNC|"
+                      + "Before second dispatch|" + "second dispatch return|"
+                      + "After dispatch|" + "ASYNC_STARTED_dispatchTest|"
+                      + "IsAsyncSupported=true|" + "IsAsyncStarted=false|"
+                      + "DispatcherType=ASYNC");
+    } else {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_startAsyncAgainTest13|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|");
+    }
     invoke();
   }
 
@@ -723,13 +752,20 @@ public class DispatchTests extends AbstractTckTest {
   @Test
   public void startAsyncAgainTest14() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "startAsyncAgainTest14");
-    TEST_PROPS.get().setProperty(SEARCH_STRING,
-        "ASYNC_NOT_STARTED_startAsyncAgainTest14|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
-            + "Before dispatch|" + "dispatch return|" + "After dispatch|"
-            + "ASYNC_STARTED_dispatchTest13|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=ASYNC|"
-            + "Before complete");
+    if(ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_startAsyncAgainTest14|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|" + "dispatch return|" + "After dispatch|"
+                      + "ASYNC_STARTED_dispatchTest13|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=ASYNC|"
+                      + "Before complete");
+    } else {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_startAsyncAgainTest14|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|");
+    }
     invoke();
   }
 
@@ -753,13 +789,20 @@ public class DispatchTests extends AbstractTckTest {
   @Test
   public void startAsyncAgainTest15() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "startAsyncAgainTest15");
-    TEST_PROPS.get().setProperty(SEARCH_STRING,
-        "ASYNC_NOT_STARTED_startAsyncAgainTest15|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
-            + "Before dispatch|" + "dispatch return|" + "After dispatch|"
-            + "ASYNC_STARTED_dispatchTest14|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=ASYNC|"
-            + "Before complete");
+    if(ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_startAsyncAgainTest15|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|" + "dispatch return|" + "After dispatch|"
+                      + "ASYNC_STARTED_dispatchTest14|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=ASYNC|"
+                      + "Before complete");
+    } else {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_startAsyncAgainTest15|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|");
+    }
     invoke();
   }
 
@@ -783,16 +826,23 @@ public class DispatchTests extends AbstractTckTest {
   @Test
   public void startAsyncAgainTest16() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "startAsyncAgainTest16");
-    TEST_PROPS.get().setProperty(SEARCH_STRING,
-        "ASYNC_NOT_STARTED_startAsyncAgainTest16|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
-            + "Before dispatch|" + "dispatch return|" + "After dispatch|"
-            + "ASYNC_STARTED_dispatchTest15|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=ASYNC|"
-            + "startAsync called|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=true|" + "DispatcherType=ASYNC|"
-            + "startAsync called again|"
-            + "Expected IllegalStateException thrown");
+    if(ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_startAsyncAgainTest16|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|" + "dispatch return|" + "After dispatch|"
+                      + "ASYNC_STARTED_dispatchTest15|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=ASYNC|"
+                      + "startAsync called|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=true|" + "DispatcherType=ASYNC|"
+                      + "startAsync called again|"
+                      + "Expected IllegalStateException thrown");
+    } else {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_startAsyncAgainTest16|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|");
+    }
     invoke();
   }
 
@@ -816,16 +866,24 @@ public class DispatchTests extends AbstractTckTest {
   @Test
   public void startAsyncAgainTest17() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "startAsyncAgainTest17");
-    TEST_PROPS.get().setProperty(SEARCH_STRING,
-        "ASYNC_NOT_STARTED_startAsyncAgainTest17|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
-            + "Before dispatch|" + "dispatch return|" + "After dispatch|"
-            + "ASYNC_STARTED_dispatchTest16|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=ASYNC|"
-            + "startAsync called|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=true|" + "DispatcherType=ASYNC|"
-            + "startAsync called again|"
-            + "Expected IllegalStateException thrown");
+    if(ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_startAsyncAgainTest17|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|" + "dispatch return|" + "After dispatch|"
+                      + "ASYNC_STARTED_dispatchTest16|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=ASYNC|"
+                      + "startAsync called|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=true|" + "DispatcherType=ASYNC|"
+                      + "startAsync called again|"
+                      + "Expected IllegalStateException thrown");
+    } else {
+      TEST_PROPS.get().setProperty(SEARCH_STRING, "ASYNC_NOT_STARTED_startAsyncAgainTest17|"
+              + "IsAsyncSupported=true|"
+              + "IsAsyncStarted=false|"
+              + "DispatcherType=REQUEST");
+    }
+
     invoke();
   }
 
@@ -967,14 +1025,21 @@ public class DispatchTests extends AbstractTckTest {
   @Test
   public void negativeDispatchTest8() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "negativeDispatchTest8");
-    TEST_PROPS.get().setProperty(SEARCH_STRING,
-        "ASYNC_NOT_STARTED_negativeDispatchTest8|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
-            + "Before dispatch|" + "dispatch return|" + "dispatch again|"
-            + "dispatch() called again|"
-            + "Expected IllegalStateException thrown|" + "After dispatch|"
-            + "ASYNC_STARTED_dispatchTest10|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=ASYNC");
+    if(ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_negativeDispatchTest8|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|" + "dispatch return|" + "dispatch again|"
+                      + "dispatch() called again|"
+                      + "Expected IllegalStateException thrown|" + "After dispatch|"
+                      + "ASYNC_STARTED_dispatchTest10|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=ASYNC");
+    } else {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_negativeDispatchTest8|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|");
+    }
     invoke();
   }
 
@@ -998,14 +1063,21 @@ public class DispatchTests extends AbstractTckTest {
   @Test
   public void negativeDispatchTest9() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "negativeDispatchTest9");
-    TEST_PROPS.get().setProperty(SEARCH_STRING,
-        "ASYNC_NOT_STARTED_negativeDispatchTest9|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
-            + "Before dispatch|" + "dispatch return|" + "dispatch again|"
-            + "dispatch() called again|"
-            + "Expected IllegalStateException thrown|" + "After dispatch|"
-            + "ASYNC_STARTED_dispatchTest10|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=ASYNC");
+    if(ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_negativeDispatchTest9|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|" + "dispatch return|" + "dispatch again|"
+                      + "dispatch() called again|"
+                      + "Expected IllegalStateException thrown|" + "After dispatch|"
+                      + "ASYNC_STARTED_dispatchTest10|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=ASYNC");
+    } else {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_negativeDispatchTest9|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|");
+    }
     invoke();
   }
 
@@ -1029,14 +1101,21 @@ public class DispatchTests extends AbstractTckTest {
   @Test
   public void negativeDispatchTest12() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "negativeDispatchTest12");
-    TEST_PROPS.get().setProperty(SEARCH_STRING,
-        "ASYNC_NOT_STARTED_negativeDispatchTest12|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
-            + "Before dispatch|" + "dispatch return|" + "dispatch again|"
-            + "dispatch(URI) called again|"
-            + "Expected IllegalStateException thrown|" + "After dispatch|"
-            + "ASYNC_STARTED_dispatchTest10|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=ASYNC");
+    if(ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_negativeDispatchTest12|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|" + "dispatch return|" + "dispatch again|"
+                      + "dispatch(URI) called again|"
+                      + "Expected IllegalStateException thrown|" + "After dispatch|"
+                      + "ASYNC_STARTED_dispatchTest10|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=ASYNC");
+    } else {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_negativeDispatchTest12|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|");
+    }
     invoke();
   }
 
@@ -1060,14 +1139,21 @@ public class DispatchTests extends AbstractTckTest {
   @Test
   public void negativeDispatchTest13() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "negativeDispatchTest13");
-    TEST_PROPS.get().setProperty(SEARCH_STRING,
-        "ASYNC_NOT_STARTED_negativeDispatchTest13|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
-            + "Before dispatch|" + "dispatch return|" + "dispatch again|"
-            + "dispatch(URI) called again|"
-            + "Expected IllegalStateException thrown|" + "After dispatch|"
-            + "ASYNC_STARTED_dispatchTest10|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=ASYNC");
+    if(ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_negativeDispatchTest13|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|" + "dispatch return|" + "dispatch again|"
+                      + "dispatch(URI) called again|"
+                      + "Expected IllegalStateException thrown|" + "After dispatch|"
+                      + "ASYNC_STARTED_dispatchTest10|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=ASYNC");
+    } else {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_negativeDispatchTest13|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "Before dispatch|");
+    }
     invoke();
   }
 
@@ -1186,13 +1272,20 @@ public class DispatchTests extends AbstractTckTest {
   @Test
   public void dispatchAfterCommitTest4() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "dispatchAfterCommitTest4");
-    TEST_PROPS.get().setProperty(SEARCH_STRING,
-        "ASYNC_NOT_STARTED_dispatchAfterCommitTest4|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
-            + "After commmit|" + "Before dispatch|" + "dispatch return|"
-            + "After dispatch|" + "ASYNC_STARTED_dispatchTest10|"
-            + "IsAsyncSupported=true|" + "IsAsyncStarted=false|"
-            + "DispatcherType=ASYNC");
+    if(ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_dispatchAfterCommitTest4|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "After commmit|" + "Before dispatch|" + "dispatch return|"
+                      + "After dispatch|" + "ASYNC_STARTED_dispatchTest10|"
+                      + "IsAsyncSupported=true|" + "IsAsyncStarted=false|"
+                      + "DispatcherType=ASYNC");
+    } else {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_dispatchAfterCommitTest4|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "After commmit|" + "Before dispatch|");
+    }
     invoke();
   }
 
@@ -1211,13 +1304,20 @@ public class DispatchTests extends AbstractTckTest {
   @Test
   public void dispatchAfterCommitTest5() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "dispatchAfterCommitTest5");
-    TEST_PROPS.get().setProperty(SEARCH_STRING,
-        "ASYNC_NOT_STARTED_dispatchAfterCommitTest5|" + "IsAsyncSupported=true|"
-            + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
-            + "After commmit|" + "Before dispatch|" + "dispatch return|"
-            + "After dispatch|" + "ASYNC_STARTED_dispatchTest10|"
-            + "IsAsyncSupported=true|" + "IsAsyncStarted=false|"
-            + "DispatcherType=ASYNC");
+    if(ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_dispatchAfterCommitTest5|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "After commmit|" + "Before dispatch|" + "dispatch return|"
+                      + "After dispatch|" + "ASYNC_STARTED_dispatchTest10|"
+                      + "IsAsyncSupported=true|" + "IsAsyncStarted=false|"
+                      + "DispatcherType=ASYNC");
+    } else {
+      TEST_PROPS.get().setProperty(SEARCH_STRING,
+              "ASYNC_NOT_STARTED_dispatchAfterCommitTest5|" + "IsAsyncSupported=true|"
+                      + "IsAsyncStarted=false|" + "DispatcherType=REQUEST|"
+                      + "After commmit|" + "Before dispatch|");
+    }
     invoke();
   }
 }

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet/dispatchtest/DispatchTests11.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet/dispatchtest/DispatchTests11.java
@@ -25,6 +25,7 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
+import servlet.tck.common.util.ServletTestUtil;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -87,7 +88,7 @@ public class DispatchTests11 extends GenericServlet {
     response.getWriter()
         .println("Before second dispatch=" + System.currentTimeMillis());
     ServletContext context = request.getServletContext().getContext(DispatchTestServlet.getDispatcherContextRoot());
-    if(context != null) {
+    if(context != null || ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
       ac.dispatch(context, "/DispatchTests?testname=dispatchTest");
     }
     // we admit cross context not supported and so validate it

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet/dispatchtest/DispatchTests11.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet/dispatchtest/DispatchTests11.java
@@ -23,11 +23,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import jakarta.servlet.AsyncContext;
-import jakarta.servlet.GenericServlet;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
+import jakarta.servlet.*;
 
 public class DispatchTests11 extends GenericServlet {
 
@@ -84,10 +80,12 @@ public class DispatchTests11 extends GenericServlet {
     AsyncContext ac = request.startAsync();
     response.getWriter()
         .println("Before second dispatch=" + System.currentTimeMillis());
-    ac.dispatch(
-        request.getServletContext().getContext(DispatchTestServlet.getDispatcherContextRoot()),
-        "/DispatchTests?testname=dispatchTest");
+    ServletContext context = request.getServletContext().getContext(DispatchTestServlet.getDispatcherContextRoot());
+    if(context != null) {
+      ac.dispatch(context, "/DispatchTests?testname=dispatchTest");
+    }
+    // we admit cross context not supported and so validate it
     response.getWriter()
-        .println("second dispatch return=" + System.currentTimeMillis());
+            .println("second dispatch return=" + System.currentTimeMillis());
   }
 }

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet/dispatchtest/DispatchTests11.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet/dispatchtest/DispatchTests11.java
@@ -19,11 +19,17 @@
  */
 package servlet.tck.api.jakarta_servlet.dispatchtest;
 
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.GenericServlet;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import jakarta.servlet.*;
 
 public class DispatchTests11 extends GenericServlet {
 

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet/dispatchtest/DispatchTests12.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet/dispatchtest/DispatchTests12.java
@@ -24,6 +24,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import jakarta.servlet.*;
+import servlet.tck.common.util.ServletTestUtil;
 
 public class DispatchTests12 extends GenericServlet {
 
@@ -81,7 +82,7 @@ public class DispatchTests12 extends GenericServlet {
     response.getWriter()
         .println("Before second dispatch=" + System.currentTimeMillis());
     ServletContext servletContext = request.getServletContext().getContext(DispatchTestServlet.getDispatcherContextRoot());
-    if(servletContext!=null) {
+    if(servletContext!=null || ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
       ac.dispatch(servletContext, "/DispatchTests?testname=dispatchTest");
     }
     response.getWriter()

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet/dispatchtest/DispatchTests12.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet/dispatchtest/DispatchTests12.java
@@ -23,11 +23,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import jakarta.servlet.AsyncContext;
-import jakarta.servlet.GenericServlet;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
+import jakarta.servlet.*;
 
 public class DispatchTests12 extends GenericServlet {
 
@@ -84,9 +80,10 @@ public class DispatchTests12 extends GenericServlet {
     AsyncContext ac = request.startAsync(request, response);
     response.getWriter()
         .println("Before second dispatch=" + System.currentTimeMillis());
-    ac.dispatch(
-        request.getServletContext().getContext(DispatchTestServlet.getDispatcherContextRoot()),
-        "/DispatchTests?testname=dispatchTest");
+    ServletContext servletContext = request.getServletContext().getContext(DispatchTestServlet.getDispatcherContextRoot());
+    if(servletContext!=null) {
+      ac.dispatch(servletContext, "/DispatchTests?testname=dispatchTest");
+    }
     response.getWriter()
         .println("second dispatch return=" + System.currentTimeMillis());
   }

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/httpsessionx/ExpireHttpSession.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/httpsessionx/ExpireHttpSession.java
@@ -38,7 +38,7 @@ public class ExpireHttpSession extends HttpServlet {
       ServletTestUtil.printResult(pw, true);
     } else {
       pw.println(
-          "From expireHttpSession: Test Failed. Session didnot expire as expected.");
+          "From expireHttpSession: Test Failed. Session did not expire as expected.");
       ServletTestUtil.printResult(pw, false);
     }
   }

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/httpsessionx/TestServlet.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/httpsessionx/TestServlet.java
@@ -44,7 +44,7 @@ public class TestServlet extends HttpTCKServlet {
       HttpServletResponse response) throws ServletException, IOException {
     ServletContext servletContext = getServletContext()
         .getContext("/servlet_jsh_httpsessionx2_web");
-    if(servletContext!=null) {
+    if(servletContext!=null || ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
       RequestDispatcher rd = servletContext
               .getRequestDispatcher("/getNewSession");
 
@@ -105,7 +105,7 @@ public class TestServlet extends HttpTCKServlet {
       HttpServletResponse response) throws ServletException, IOException {
     ServletContext servletContext = getServletContext()
         .getContext("/servlet_jsh_httpsessionx2_web");
-    if(servletContext!=null) {
+    if(servletContext!=null || ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
       RequestDispatcher rd = servletContext
               .getRequestDispatcher("/setMaxInterval");
 
@@ -119,7 +119,7 @@ public class TestServlet extends HttpTCKServlet {
       HttpServletResponse response) throws ServletException, IOException {
     ServletContext servletContext = getServletContext()
         .getContext("/servlet_jsh_httpsessionx2_web");
-    if(servletContext!=null) {
+    if(servletContext!=null || ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
       RequestDispatcher rd = servletContext
               .getRequestDispatcher("/setMaxInterval");
       rd.forward(request, response);
@@ -132,7 +132,7 @@ public class TestServlet extends HttpTCKServlet {
       HttpServletResponse response) throws ServletException, IOException {
     ServletContext servletContext = getServletContext()
         .getContext("/servlet_jsh_httpsessionx2_web");
-    if(servletContext!=null) {
+    if(servletContext!=null || ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
       RequestDispatcher rd = servletContext
               .getRequestDispatcher("/expireHttpSession");
 
@@ -147,7 +147,7 @@ public class TestServlet extends HttpTCKServlet {
 
     ServletContext servletContext = getServletContext()
         .getContext("/servlet_jsh_httpsessionx2_web");
-    if(servletContext!=null) {
+    if(servletContext!=null || ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
       RequestDispatcher rd = servletContext
               .getRequestDispatcher("/expireHttpSession");
 
@@ -182,7 +182,7 @@ public class TestServlet extends HttpTCKServlet {
 
     ServletContext servletContext = getServletContext()
         .getContext("/servlet_jsh_httpsessionx2_web");
-    if(servletContext!=null) {
+    if(servletContext!=null || ServletTestUtil.SUPPORT_CROSS_CONTEXT) {
       RequestDispatcher rd = servletContext
               .getRequestDispatcher("/invalidateHttpSession");
 

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/httpsessionx/TestServlet.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/httpsessionx/TestServlet.java
@@ -44,10 +44,15 @@ public class TestServlet extends HttpTCKServlet {
       HttpServletResponse response) throws ServletException, IOException {
     ServletContext servletContext = getServletContext()
         .getContext("/servlet_jsh_httpsessionx2_web");
-    RequestDispatcher rd = servletContext
-        .getRequestDispatcher("/getNewSession");
+    if(servletContext!=null) {
+      RequestDispatcher rd = servletContext
+              .getRequestDispatcher("/getNewSession");
 
-    rd.include(request, response);
+      rd.include(request, response);
+    } else {
+      response.getWriter().println("Test PASSED");
+    }
+
   }
 
   public void setMaxInactiveIntervalTest(HttpServletRequest request,
@@ -100,30 +105,41 @@ public class TestServlet extends HttpTCKServlet {
       HttpServletResponse response) throws ServletException, IOException {
     ServletContext servletContext = getServletContext()
         .getContext("/servlet_jsh_httpsessionx2_web");
-    RequestDispatcher rd = servletContext
-        .getRequestDispatcher("/setMaxInterval");
+    if(servletContext!=null) {
+      RequestDispatcher rd = servletContext
+              .getRequestDispatcher("/setMaxInterval");
 
-    rd.include(request, response);
+      rd.include(request, response);
+    } else {
+      response.getWriter().println("Test PASSED");
+    }
   }
 
   public void setMaxInactiveIntervalxfTest(HttpServletRequest request,
       HttpServletResponse response) throws ServletException, IOException {
     ServletContext servletContext = getServletContext()
         .getContext("/servlet_jsh_httpsessionx2_web");
-    RequestDispatcher rd = servletContext
-        .getRequestDispatcher("/setMaxInterval");
-
-    rd.forward(request, response);
+    if(servletContext!=null) {
+      RequestDispatcher rd = servletContext
+              .getRequestDispatcher("/setMaxInterval");
+      rd.forward(request, response);
+    } else {
+      response.getWriter().println("Test PASSED");
+    }
   }
 
   public void expireHttpSessionxriTest(HttpServletRequest request,
       HttpServletResponse response) throws ServletException, IOException {
     ServletContext servletContext = getServletContext()
         .getContext("/servlet_jsh_httpsessionx2_web");
-    RequestDispatcher rd = servletContext
-        .getRequestDispatcher("/expireHttpSession");
+    if(servletContext!=null) {
+      RequestDispatcher rd = servletContext
+              .getRequestDispatcher("/expireHttpSession");
 
-    rd.include(request, response);
+      rd.include(request, response);
+    } else {
+      response.getWriter().println("Test PASSED");
+    }
   }
 
   public void expireHttpSessionxrfTest(HttpServletRequest request,
@@ -131,10 +147,14 @@ public class TestServlet extends HttpTCKServlet {
 
     ServletContext servletContext = getServletContext()
         .getContext("/servlet_jsh_httpsessionx2_web");
-    RequestDispatcher rd = servletContext
-        .getRequestDispatcher("/expireHttpSession");
+    if(servletContext!=null) {
+      RequestDispatcher rd = servletContext
+              .getRequestDispatcher("/expireHttpSession");
 
-    rd.forward(request, response);
+      rd.forward(request, response);
+    } else {
+      response.getWriter().println("Test PASSED");
+    }
   }
 
   public void invalidateSessionTest(HttpServletRequest request,
@@ -162,9 +182,13 @@ public class TestServlet extends HttpTCKServlet {
 
     ServletContext servletContext = getServletContext()
         .getContext("/servlet_jsh_httpsessionx2_web");
-    RequestDispatcher rd = servletContext
-        .getRequestDispatcher("/invalidateHttpSession");
+    if(servletContext!=null) {
+      RequestDispatcher rd = servletContext
+              .getRequestDispatcher("/invalidateHttpSession");
 
-    rd.include(request, response);
+      rd.include(request, response);
+    } else {
+      response.getWriter().println("Test PASSED");
+    }
   }
 }

--- a/tck/tck-runtime/src/main/java/servlet/tck/common/util/ServletTestUtil.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/common/util/ServletTestUtil.java
@@ -43,7 +43,7 @@ public class ServletTestUtil {
 
   private static Logger LOGGER = LoggerFactory.getLogger(ServletTestUtil.class);
 
-  public static final boolean SUPPORT_CROSS_CONTEXT = Boolean.parseBoolean(System.getProperty("servlet.tck.support.crossContext", "true"));
+  public static boolean SUPPORT_CROSS_CONTEXT = Boolean.parseBoolean(System.getProperty("servlet.tck.support.crossContext", "true"));
 
   /**
    * Private as this class contains only public static methods.

--- a/tck/tck-runtime/src/main/java/servlet/tck/common/util/ServletTestUtil.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/common/util/ServletTestUtil.java
@@ -43,6 +43,8 @@ public class ServletTestUtil {
 
   private static Logger LOGGER = LoggerFactory.getLogger(ServletTestUtil.class);
 
+  public static final boolean SUPPORT_CROSS_CONTEXT = Boolean.parseBoolean(System.getProperty("servlet.tck.support.crossContext", "true"));
+
   /**
    * Private as this class contains only public static methods.
    */
@@ -177,8 +179,7 @@ public class ServletTestUtil {
     Arrays.sort(values);
     int len = al.size();
     for (int i = 0; i < len; i++) {
-      Object val = null;
-      val = (String) al.get(i);
+      Object val = (String) al.get(i);
       LOGGER.debug("[ServletTestUtil] val= {}", val);
       if (!allowDuplicates) {
         if (foundValues.contains(val)) {
@@ -193,7 +194,6 @@ public class ServletTestUtil {
       if ((Arrays.binarySearch(values, val) < 0) && (enforceSizes)) {
         LOGGER.info("[ServletTestUtil] Value '{}' not found.", val);
         valuesFound = false;
-        continue;
       }
     }
 


### PR DESCRIPTION
The idea is to keep the tests for containers supporting it.
But if not containers must set the system property `servlet.tck.support.crossContext` to `false`
