### PR TITLE
Remove Servlet parent

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2022 Oracle and/or its affiliates and others.
+    Copyright (c) 1997, 2024 Oracle and/or its affiliates and others.
     All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -22,11 +22,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakarta.servlet</groupId>
-        <artifactId>servlet-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <groupId>org.eclipse.ee4j</groupId>
+        <artifactId>project</artifactId>
+        <version>1.0.9</version>
+        <relativePath/>
     </parent>
 
+    <groupId>jakarta.servlet</groupId>
+    <version>6.1.0-SNAPSHOT</version>
     <artifactId>tck</artifactId>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
If I am reading the CI errors correctly, the use of Servlet parent is preventing the TCK module from completing an independent release. We need to release the API and the TCK separately.