### PR TITLE
TCK updates - cookies

### DIFF
--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/CookieTests.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/CookieTests.java
@@ -261,8 +261,8 @@ public class CookieTests extends AbstractTckTest {
     String body = null;
 
     HttpExchange request = new HttpExchange("GET " + getContextRoot() + "/"
-            + getServletName() + "?testname=" + testName + " HTTP/1.1", _hostname,
-            _port);
+        + getServletName() + "?testname=" + testName + " HTTP/1.1", _hostname,
+        _port);
 
     try {
       response = request.execute();
@@ -275,7 +275,9 @@ public class CookieTests extends AbstractTckTest {
       List<String> cookiesHeaders = response.getResponseHeaders("Set-Cookie");
       int i = 0;
       while (i < cookiesHeaders.size()) {
-        logger.trace("Checking set-cookiei {}:{}", String.valueOf(i), cookiesHeaders.get(i));
+        if(logger.isTraceEnabled()) {
+          logger.trace("Checking set-cookiei {}:{}", String.valueOf(i), cookiesHeaders.get(i));
+        }
         List<HttpCookie> cookies = HttpCookie.parse(cookiesHeaders.get(i));
         Optional<HttpCookie> optionalHttpCookie = cookies.stream().filter(httpCookie -> httpCookie.getName().equals("name1"))
                 .findFirst();
@@ -289,8 +291,9 @@ public class CookieTests extends AbstractTckTest {
         i++;
       }
 
-      if (!foundcookie)
+      if (!foundcookie) {
         throw new Exception("The test cookie was not located in the response");
+      }
     } catch (Throwable t) {
       throw new Exception("Exception occurred:" + t, t);
     }
@@ -302,10 +305,10 @@ public class CookieTests extends AbstractTckTest {
     try {
       Date resultDate = sdf.parse(resultStringDate);
       Date expectedDate = sdf
-              .parse(dateHeader.substring(dateHeader.indexOf(": ") + 2).trim());
+          .parse(dateHeader.substring(dateHeader.indexOf(": ") + 2).trim());
       if (resultDate.before(expectedDate)) {
         throw new Exception("The expiry date was incorrect, expected ="
-                + expectedDate + ", result = " + resultDate);
+            + expectedDate + ", result = " + resultDate);
       }
     } catch (Throwable t) {
       throw new Exception("Exception occurred: " + t);

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/CookieTests.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/CookieTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021 Oracle and/or its affiliates and others.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -14,11 +14,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
-/*
- * $Id$
- */
-
 package servlet.tck.api.jakarta_servlet_http.cookie;
 
 import servlet.tck.common.client.AbstractTckTest;
@@ -133,18 +128,12 @@ public class CookieTests extends AbstractTckTest {
    *
    * @assertion_ids: Servlet:JAVADOC:439
    *
-   * @test_Strategy: Client sends a version 0 and 1 cookie to the servlet.
-   * Servlet verifies values and returns result to client
+   * @test_Strategy: Servlet tests method and returns result to client
    */
   @Test
   public void getDomainTest() throws Exception {
-    // version 1
-    TEST_PROPS.get().setProperty(REQUEST_HEADERS,
-            "Cookie: $Version=1; name1=value1; $Domain=" + _hostname
-                    + "; $Path=/servlet_jsh_cookie_web");
     TEST_PROPS.get().setProperty(APITEST, "getDomainTest");
     invoke();
-
   }
 
   /*
@@ -169,15 +158,8 @@ public class CookieTests extends AbstractTckTest {
    */
   @Test
   public void getNameTest() throws Exception {
-    // version 0
     TEST_PROPS.get().setProperty(REQUEST_HEADERS, "Cookie: name1=value1; Domain="
             + _hostname + "; Path=/servlet_jsh_cookie_web");
-    TEST_PROPS.get().setProperty(APITEST, "getNameTest");
-    invoke();
-    // version 1
-    TEST_PROPS.get().setProperty(REQUEST_HEADERS,
-            "Cookie: $Version=1; name1=value1; $Domain=" + _hostname
-                    + "; $Path=/servlet_jsh_cookie_web");
     TEST_PROPS.get().setProperty(APITEST, "getNameTest");
     invoke();
   }
@@ -191,9 +173,6 @@ public class CookieTests extends AbstractTckTest {
    */
   @Test
   public void getPathTest() throws Exception {
-    TEST_PROPS.get().setProperty(REQUEST_HEADERS,
-            "Cookie: $Version=1; name1=value1; $Domain=" + _hostname
-                    + "; $Path=/servlet_jsh_cookie_web");
     TEST_PROPS.get().setProperty(APITEST, "getPathTest");
     invoke();
   }
@@ -211,6 +190,12 @@ public class CookieTests extends AbstractTckTest {
     invoke();
   }
 
+  @Test
+  public void getAttributeSecureTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "getAttributeSecureTest");
+    invoke();
+  }
+
   /*
    * @testName: getValueTest
    *
@@ -220,16 +205,17 @@ public class CookieTests extends AbstractTckTest {
    */
   @Test
   public void getValueTest() throws Exception {
-    // version 0
     TEST_PROPS.get().setProperty(REQUEST_HEADERS, "Cookie: name1=value1; Domain="
             + _hostname + "; Path=/servlet_jsh_cookie_web");
     TEST_PROPS.get().setProperty(APITEST, "getValueTest");
     invoke();
-    // version 1
-    TEST_PROPS.get().setProperty(REQUEST_HEADERS,
-            "Cookie: $Version=1; name1=value1; $Domain=" + _hostname
-                    + "; $Path=/servlet_jsh_cookie_web");
-    TEST_PROPS.get().setProperty(APITEST, "getValueTest");
+  }
+
+  @Test
+  public void getValueQuotedTest() throws Exception {
+    TEST_PROPS.get().setProperty(REQUEST_HEADERS, "Cookie: name1=\"value1\"; Domain="
+            + _hostname + "; Path=/servlet_jsh_cookie_web");
+    TEST_PROPS.get().setProperty(APITEST, "getValueQuotedTest");
     invoke();
   }
 
@@ -242,16 +228,7 @@ public class CookieTests extends AbstractTckTest {
    */
   @Test
   public void getVersionTest() throws Exception {
-    // version 0
-    TEST_PROPS.get().setProperty(REQUEST_HEADERS, "Cookie: name1=value1; Domain="
-            + _hostname + "; Path=/servlet_jsh_cookie_web");
-    TEST_PROPS.get().setProperty(APITEST, "getVersionVer0Test");
-    invoke();
-    // version 1
-    TEST_PROPS.get().setProperty(REQUEST_HEADERS,
-            "Cookie: $Version=1; name1=value1; $Domain=" + _hostname
-                    + "; $Path=/servlet_jsh_cookie_web");
-    TEST_PROPS.get().setProperty(APITEST, "getVersionVer1Test");
+    TEST_PROPS.get().setProperty(APITEST, "getVersionTest");
     invoke();
   }
 
@@ -292,14 +269,13 @@ public class CookieTests extends AbstractTckTest {
       dateHeader = response.getResponseHeader("testDate")
               .orElseThrow(() -> new NullPointerException("testDate is empty")).getValue();
 
-
-      logger.trace("Found {} set-cookie entry", response.getResponseHeaders("Set-Cookie").size());
+      logger.trace("Found {} set-cookie entry", String.valueOf(response.getResponseHeaders("Set-Cookie").size()));
 
       boolean foundcookie = false;
       List<String> cookiesHeaders = response.getResponseHeaders("Set-Cookie");
       int i = 0;
       while (i < cookiesHeaders.size()) {
-        logger.trace("Checking set-cookiei {}:{}", i, cookiesHeaders.get(i));
+        logger.trace("Checking set-cookiei {}:{}", String.valueOf(i), cookiesHeaders.get(i));
         List<HttpCookie> cookies = HttpCookie.parse(cookiesHeaders.get(i));
         Optional<HttpCookie> optionalHttpCookie = cookies.stream().filter(httpCookie -> httpCookie.getName().equals("name1"))
                 .findFirst();
@@ -335,7 +311,7 @@ public class CookieTests extends AbstractTckTest {
       throw new Exception("Exception occurred: " + t);
     }
 
-    if (!body.contains(Data.PASSED)) {
+    if (body == null || !body.contains(Data.PASSED)) {
       throw new Exception("The string: " + Data.PASSED + " not found in response");
     }
   }
@@ -350,8 +326,76 @@ public class CookieTests extends AbstractTckTest {
   @Test
   public void setMaxAgeZeroTest() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "setMaxAgeZeroTest");
-    TEST_PROPS.get().setProperty(EXPECTED_HEADERS, "Set-Cookie:name1=value1##Max-Age=0");
+    // RFC 6265 - server should only send +ve values for Max-Age
+    TEST_PROPS.get().setProperty(EXPECTED_HEADERS, "Set-Cookie:name1=value1##!Max-Age##Expires=");
     invoke();
+  }
+
+  @Test
+  public void setMaxAgeZeroDateTest() throws Exception {
+    String testName = "setMaxAgeZeroTest";
+    HttpResponse response = null;
+    Date expiryDate = null;
+    String body = null;
+
+    HttpExchange request = new HttpExchange("GET " + getContextRoot() + "/"
+            + getServletName() + "?testname=" + testName + " HTTP/1.1", _hostname,
+            _port);
+
+    try {
+      response = request.execute();
+
+      logger.trace("Found {} set-cookie entry", String.valueOf(response.getResponseHeaders("Set-Cookie").size()));
+
+      boolean foundcookie = false;
+      List<String> cookiesHeaders = response.getResponseHeaders("Set-Cookie");
+      int i = 0;
+      while (i < cookiesHeaders.size()) {
+        logger.trace("Checking set-cookie i {}:{}", String.valueOf(i), cookiesHeaders.get(i));
+        List<HttpCookie> cookies = HttpCookie.parse(cookiesHeaders.get(i));
+        Optional<HttpCookie> optionalHttpCookie = cookies.stream().filter(httpCookie -> httpCookie.getName().equals("name1"))
+                .findFirst();
+        if (optionalHttpCookie.isPresent()) {
+          HttpCookie httpCookie = optionalHttpCookie.get();
+          expiryDate = new Date(httpCookie.getMaxAge());
+          body = response.getResponseBodyAsString();
+          foundcookie = true;
+          break;
+        }
+        i++;
+      }
+
+      if (!foundcookie)
+        throw new Exception("The test cookie was not located in the response");
+    } catch (Throwable t) {
+      throw new Exception("Exception occurred:" + t, t);
+    }
+
+    // put expiry date into GMT
+    SimpleDateFormat sdf = new SimpleDateFormat(TestServlet.CUSTOM_HEADER_DATE_FORMAT);
+    sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+    String resultStringDate = sdf.format(expiryDate);
+
+    try {
+      Date resultDate = sdf.parse(resultStringDate);
+      /*
+       * RFC 6265 does not allow the server to send a Max-Age attribute with value zero. The implication from the client
+       * requirements is that an expires header should be sent with the earliest representable date. There is a fair
+       * amount of room for interpretation in all of this so check that whatever has been sent is in the past.
+       */
+      Date expectedDate = new Date(System.currentTimeMillis());
+      if (resultDate.after(expectedDate)) {
+        throw new Exception("The expiry date was incorrect, expected ="
+                + expectedDate + ", result = " + resultDate);
+      }
+    } catch (Throwable t) {
+      throw new Exception("Exception occurred: " + t);
+    }
+
+    if (body == null || !body.contains(Data.PASSED)) {
+      throw new Exception("The string: " + Data.PASSED + " not found in response");
+    }
+
   }
 
   /*
@@ -393,9 +437,19 @@ public class CookieTests extends AbstractTckTest {
    */
   @Test
   public void setSecureTest() throws Exception {
-    TEST_PROPS.get().setProperty(APITEST, "setSecureVer0Test");
+    TEST_PROPS.get().setProperty(APITEST, "setSecureTest");
     invoke();
-    TEST_PROPS.get().setProperty(APITEST, "setSecureVer1Test");
+  }
+
+  @Test
+  public void setAttributeSecureTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "setAttributeSecureTest");
+    invoke();
+  }
+
+  @Test
+  public void setAttributeSecureInvalidTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "setAttributeSecureInvalidTest");
     invoke();
   }
 
@@ -408,9 +462,7 @@ public class CookieTests extends AbstractTckTest {
    */
   @Test
   public void setValueTest() throws Exception {
-    TEST_PROPS.get().setProperty(APITEST, "setValueVer0Test");
-    invoke();
-    TEST_PROPS.get().setProperty(APITEST, "setValueVer1Test");
+    TEST_PROPS.get().setProperty(APITEST, "setValueTest");
     invoke();
   }
 
@@ -452,6 +504,43 @@ public class CookieTests extends AbstractTckTest {
   @Test
   public void getAttributesTest() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "getAttributesTest");
+    invoke();
+  }
+
+  @Test
+  public void getHttpOnlyTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "getHttpOnlyTest");
+    invoke();
+  }
+
+  @Test
+  public void getAttributeHttpOnlyTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "getAttributeHttpOnlyTest");
+    invoke();
+  }
+
+  @Test
+  public void setHttpOnlyTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "setHttpOnlyTest");
+    invoke();
+  }
+
+  @Test
+  public void setAttributeHttpOnlyTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "setAttributeHttpOnlyTest");
+    invoke();
+  }
+
+  @Test
+  public void setAttributeHttpOnlyInvalidTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "setAttributeHttpOnlyInvalidTest");
+    invoke();
+  }
+
+  @Test
+  public void setPartitionedTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "setPartitionedTest");
+    TEST_PROPS.get().setProperty(EXPECTED_HEADERS, "Set-Cookie:name1=value1##Partitioned##!Partitioned=");
     invoke();
   }
 }

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/TestServlet.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/TestServlet.java
@@ -3,7 +3,7 @@
  *  *
  *  * The Apache Software License, Version 1.1
  *  *
- *  * Copyright (c) 2001, 2021 Oracle and/or its affiliates and others.
+ *  * Copyright (c) 2001, 2024 Oracle and/or its affiliates and others.
  *  * All rights reserved.
  *  * Copyright (c) 1999-2001 The Apache Software Foundation.  All rights
  *  * reserved.
@@ -75,6 +75,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public class TestServlet extends HttpTCKServlet {
+
+  private static final long serialVersionUID = 1L;
 
   public static String CUSTOM_HEADER_DATE_FORMAT = "yyyy-MM-dd HH:mm";
 

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/TestServlet.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/TestServlet.java
@@ -69,7 +69,6 @@ import java.util.TimeZone;
 import servlet.tck.common.servlets.HttpTCKServlet;
 import servlet.tck.common.util.ServletTestUtil;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -81,7 +80,7 @@ public class TestServlet extends HttpTCKServlet {
   public static String CUSTOM_HEADER_DATE_FORMAT = "yyyy-MM-dd HH:mm";
 
   public void cloneTest(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
@@ -103,7 +102,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void constructorTest(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
@@ -127,7 +126,7 @@ public class TestServlet extends HttpTCKServlet {
 
   public void constructorIllegalArgumentExceptionTest(
       HttpServletRequest request, HttpServletResponse response)
-      throws ServletException, IOException {
+      throws IOException {
     String[] invalidNameValues = { ",test", ";test", " test", "\ttest", "\ntest" };
 
     PrintWriter pw = response.getWriter();
@@ -154,7 +153,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void getCommentTest(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
     PrintWriter pw = response.getWriter();
     boolean passed = false;
     Cookie testCookie = new Cookie("name1", "value1");
@@ -177,7 +176,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void getCommentNullTest(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
     PrintWriter pw = response.getWriter();
     boolean passed = false;
     Cookie testCookie = new Cookie("name1", "value1");
@@ -194,7 +193,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void getDomainTest(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
@@ -232,7 +231,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void getMaxAgeTest(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = true;
@@ -265,7 +264,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void getNameTest(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
@@ -281,7 +280,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void getPathTest(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
@@ -313,7 +312,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void getSecureTest(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
@@ -335,7 +334,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void getValueTest(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
@@ -365,7 +364,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void getVersionVer0Test(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     // Version should be hard-coded to zero
     PrintWriter pw = response.getWriter();
@@ -391,7 +390,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void getVersionVer1Test(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     // Version should be hard-coded to zero
     PrintWriter pw = response.getWriter();
@@ -417,7 +416,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void setDomainTest(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
@@ -447,7 +446,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void setMaxAgePositiveTest(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     Cookie testCookie = new Cookie("name1", "value1");
@@ -467,7 +466,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void setMaxAgeZeroTest(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     Cookie testCookie = new Cookie("name1", "value1");
@@ -480,7 +479,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void setMaxAgeNegativeTest(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     Cookie testCookie = new Cookie("name1", "value1");
@@ -493,7 +492,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void setPathTest(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
@@ -523,7 +522,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void setSecureVer0Test(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
@@ -546,7 +545,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void setSecureVer1Test(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
@@ -569,7 +568,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void setValueVer0Test(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
@@ -599,7 +598,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void setValueVer1Test(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
@@ -629,7 +628,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void setVersionVer0Test(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
 
     // Expected to be hard-coded to zero
     PrintWriter pw = response.getWriter();
@@ -654,7 +653,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void setVersionVer1Test(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws IOException {
     PrintWriter pw = response.getWriter();
     boolean passed = false;
     Cookie testCookie = new Cookie("name1", "value1");

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/TestServlet.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/TestServlet.java
@@ -77,6 +77,8 @@ public class TestServlet extends HttpTCKServlet {
 
   private static final long serialVersionUID = 1L;
 
+  private static final String EMPTY_STRING = "";
+
   public static String CUSTOM_HEADER_DATE_FORMAT = "yyyy-MM-dd HH:mm";
 
   public void cloneTest(@SuppressWarnings("unused") HttpServletRequest request,
@@ -127,6 +129,7 @@ public class TestServlet extends HttpTCKServlet {
   public void constructorIllegalArgumentExceptionTest(
       @SuppressWarnings("unused") HttpServletRequest request, HttpServletResponse response)
       throws IOException {
+
     String[] invalidNameValues = { ",test", ";test", " test", "\ttest", "\ntest" };
 
     PrintWriter pw = response.getWriter();
@@ -135,7 +138,8 @@ public class TestServlet extends HttpTCKServlet {
       pw.println("Attempting to create new Cookie with invalid name "
           + "value: '" + invalidNameValues[i] + "'");
       try {
-        new Cookie(invalidNameValues[i], "someValue");
+        @SuppressWarnings("unused")
+        Cookie c = new Cookie(invalidNameValues[i], "someValue");
         pw.println("Test FAILED.  IllegalArgumentException not thrown"
             + " for invalid name value.");
       } catch (Throwable t) {
@@ -152,8 +156,10 @@ public class TestServlet extends HttpTCKServlet {
     }
   }
 
+  @Deprecated
   public void getCommentTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
+
     PrintWriter pw = response.getWriter();
     boolean passed = false;
     Cookie testCookie = new Cookie("name1", "value1");
@@ -172,11 +178,12 @@ public class TestServlet extends HttpTCKServlet {
       pw.println("Actual = |" + result + "| ");
     }
     ServletTestUtil.printResult(pw, passed);
-
   }
 
+  @Deprecated
   public void getCommentNullTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
+
     PrintWriter pw = response.getWriter();
     boolean passed = false;
     Cookie testCookie = new Cookie("name1", "value1");
@@ -184,7 +191,7 @@ public class TestServlet extends HttpTCKServlet {
 
     if (result != null) {
       passed = false;
-      pw.println("getComment() returned a non-null value");
+      pw.println("getComment() returned a non-null result");
       pw.println("Actual = |" + result + "|");
     } else {
       passed = true;
@@ -192,40 +199,26 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void getDomainTest(HttpServletRequest request,
+  public void getDomainTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
-    Cookie[] cookie = request.getCookies();
-    // RFC 6265 treats the domain attribute of an RFC 2109 cookie as a separate
-    // cookie
-    int index = ServletTestUtil.findCookie(cookie, "$Domain");
-    if (index >= 0) {
-      String host = request.getHeader("host");
-      int col = host.indexOf(':');
-      if (col > -1) {
-        host = host.substring(0, col).trim();
-      }
+    Cookie testCookie = new Cookie("name1", "value1");
 
-      // get
-      String result = cookie[index].getValue();
-      if (result != null) {
-        if (!result.equalsIgnoreCase(host)) {
-          passed = false;
-          pw.println("getDomain() returned an incorrect result");
-          pw.println("Expected = \"" + host + "\"");
-          pw.println("Actual =  \"" + result + "\"");
-        } else {
-          passed = true;
-        }
-      } else {
-        passed = false;
-        pw.println("getDomain() returned a null result ");
-      }
+    // set and get
+    String expectedResult = "foo.bar";
+    testCookie.setDomain(expectedResult);
+    String result = testCookie.getDomain();
+
+    response.addCookie(testCookie);
+    if (expectedResult.equals(result)) {
+      passed = true;
     } else {
       passed = false;
-      pw.println("Error: The expected cookie was not received from the client");
+      pw.println("getDomain() returned an incorrect result");
+      pw.println("Expected = " + expectedResult + " ");
+      pw.println("Actual = |" + result + "| ");
     }
     ServletTestUtil.printResult(pw, passed);
   }
@@ -243,7 +236,7 @@ public class TestServlet extends HttpTCKServlet {
 
     if (result != expectedResult) {
       passed = false;
-      pw.println("getMaxAge() returned an incorrect result ");
+      pw.println("getMaxAge() returned an incorrect result");
       pw.println("Expected = " + expectedResult + " ");
       pw.println("Actual = |" + result + "| ");
 
@@ -284,29 +277,21 @@ public class TestServlet extends HttpTCKServlet {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
-    Cookie[] cookie = request.getCookies();
-    // RFC 6265 treats the path attribute of an RFC 2109 cookie as a separate
-    // cookie
-    int index = ServletTestUtil.findCookie(cookie, "$Path");
-    if (index >= 0) {
-      String expectedResult = request.getContextPath();
-      String result = cookie[index].getValue();
-      if (result != null) {
-        if (!result.equals(expectedResult)) {
-          passed = false;
-          pw.println("getPath() returned an incorrect result ");
-          pw.println("Expected = " + expectedResult + " ");
-          pw.println("Actual = |" + result + "| ");
-        } else {
-          passed = true;
-        }
-      } else {
-        passed = false;
-        pw.println("Error: getPath() returned a null result");
-      }
+    Cookie testCookie = new Cookie("name1", "value1");
+
+    // set and get
+    String expectedResult = request.getContextPath();
+    testCookie.setPath(expectedResult);
+    String result = testCookie.getPath();
+
+    response.addCookie(testCookie);
+    if (expectedResult.equals(result)) {
+      passed = true;
     } else {
       passed = false;
-      pw.println("Error: The expected cookie was not received from the client");
+      pw.println("getPath() returned an incorrect result");
+      pw.println("Expected = " + expectedResult + " ");
+      pw.println("Actual = |" + result + "| ");
     }
     ServletTestUtil.printResult(pw, passed);
   }
@@ -324,8 +309,28 @@ public class TestServlet extends HttpTCKServlet {
     response.addCookie(testCookie);
     if (result != expectedResult) {
       passed = false;
-      pw.println("getSecure() returned an incorrect result ");
+      pw.println("getSecure() returned an incorrect result");
       pw.println("Expected = " + expectedResult + " ");
+      pw.println("Actual = |" + result + "| ");
+    } else {
+      passed = true;
+    }
+    ServletTestUtil.printResult(pw, passed);
+  }
+
+  public void getAttributeSecureTest(@SuppressWarnings("unused") HttpServletRequest request,
+	      HttpServletResponse response) throws IOException {
+
+    PrintWriter pw = response.getWriter();
+    boolean passed = false;
+    Cookie testCookie = new Cookie("name1", "value1");
+
+    String result = testCookie.getAttribute("secure");
+
+    response.addCookie(testCookie);
+    if (result != null) {
+      passed = false;
+      pw.println("getAttribute(\"Secure\") returned non-null result");
       pw.println("Actual = |" + result + "| ");
     } else {
       passed = true;
@@ -335,13 +340,22 @@ public class TestServlet extends HttpTCKServlet {
 
   public void getValueTest(HttpServletRequest request,
       HttpServletResponse response) throws IOException {
+    doGetValueTest(request, response, "value1");
+  }
+
+  public void getValueQuotedTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    doGetValueTest(request, response, "\"value1\"");
+  }
+
+  private void doGetValueTest(HttpServletRequest request,
+	      HttpServletResponse response, String expectedResult) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
     Cookie[] cookie = request.getCookies();
     int index = ServletTestUtil.findCookie(cookie, "name1");
     if (index >= 0) {
-      String expectedResult = "value1";
       String result = cookie[index].getValue();
       if (result != null) {
         if (!result.equals(expectedResult)) {
@@ -354,7 +368,7 @@ public class TestServlet extends HttpTCKServlet {
         }
       } else {
         passed = false;
-        pw.println("Error: getPath() returned a null result");
+        pw.println("Error: getValue() returned a null result");
       }
     } else {
       passed = false;
@@ -363,54 +377,26 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void getVersionVer0Test(HttpServletRequest request,
+  @Deprecated
+  public void getVersionTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     // Version should be hard-coded to zero
     PrintWriter pw = response.getWriter();
     boolean passed = false;
-    Cookie[] cookie = request.getCookies();
-    int index = ServletTestUtil.findCookie(cookie, "name1");
-    if (index >= 0) {
-      int expectedResult = 0;
-      int result = cookie[index].getVersion();
-      if (result != expectedResult) {
-        passed = false;
-        pw.println("getVersion() returned incorrect result ");
-        pw.println("Expected = " + expectedResult + " ");
-        pw.println("Actual = |" + result + "| ");
-      } else {
-        passed = true;
-      }
-    } else {
-      passed = false;
-      pw.println("Error: The expected cookie was not received from the client");
-    }
-    ServletTestUtil.printResult(pw, passed);
-  }
+    Cookie testCookie = new Cookie("name1", "value1");
 
-  public void getVersionVer1Test(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
+    int expectedResult = 0;
+    int result = testCookie.getVersion();
 
-    // Version should be hard-coded to zero
-    PrintWriter pw = response.getWriter();
-    boolean passed = false;
-    Cookie[] cookie = request.getCookies();
-    int index = ServletTestUtil.findCookie(cookie, "name1");
-    if (index >= 0) {
-      int expectedResult = 0;
-      int result = cookie[index].getVersion();
-      if (result != expectedResult) {
-        passed = false;
-        pw.println("getVersion() returned incorrect result ");
-        pw.println("Expected = " + expectedResult + " ");
-        pw.println("Actual = |" + result + "| ");
-      } else {
-        passed = true;
-      }
-    } else {
+    response.addCookie(testCookie);
+    if (result != expectedResult) {
       passed = false;
-      pw.println("Error: The expected cookie was not received from the client");
+      pw.println("getVersion() returned an incorrect result");
+      pw.println("Expected = " + expectedResult + " ");
+      pw.println("Actual = |" + result + "| ");
+    } else {
+      passed = true;
     }
     ServletTestUtil.printResult(pw, passed);
   }
@@ -421,7 +407,6 @@ public class TestServlet extends HttpTCKServlet {
     PrintWriter pw = response.getWriter();
     boolean passed = false;
     Cookie testCookie = new Cookie("name1", "value1");
-    testCookie.setVersion(0);
 
     String expectedResult = "ENG.COM";
     testCookie.setDomain(expectedResult);
@@ -450,16 +435,15 @@ public class TestServlet extends HttpTCKServlet {
 
     PrintWriter pw = response.getWriter();
     Cookie testCookie = new Cookie("name1", "value1");
-    testCookie.setVersion(0);
 
     testCookie.setMaxAge(2);
+    response.addCookie(testCookie);
+
     // Use a custom format to ensure Locale independence
     SimpleDateFormat sdf = new SimpleDateFormat(CUSTOM_HEADER_DATE_FORMAT);
     sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
     Date currDate = new Date();
     String dateString = sdf.format(currDate);
-
-    response.addCookie(testCookie);
     response.addHeader("testDate", dateString);
 
     ServletTestUtil.printResult(pw, true);
@@ -470,7 +454,6 @@ public class TestServlet extends HttpTCKServlet {
 
     PrintWriter pw = response.getWriter();
     Cookie testCookie = new Cookie("name1", "value1");
-    testCookie.setVersion(0);
 
     testCookie.setMaxAge(0);
     response.addCookie(testCookie);
@@ -483,7 +466,6 @@ public class TestServlet extends HttpTCKServlet {
 
     PrintWriter pw = response.getWriter();
     Cookie testCookie = new Cookie("name1", "value1");
-    testCookie.setVersion(0);
 
     testCookie.setMaxAge(-1);
     response.addCookie(testCookie);
@@ -497,7 +479,6 @@ public class TestServlet extends HttpTCKServlet {
     PrintWriter pw = response.getWriter();
     boolean passed = false;
     Cookie testCookie = new Cookie("name1", "value1");
-    testCookie.setVersion(0);
 
     String expectedResult = "\"/servlet_jsh_cookie_web\"";
     testCookie.setPath(expectedResult);
@@ -521,15 +502,15 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void setSecureVer0Test(@SuppressWarnings("unused") HttpServletRequest request,
+  public void setSecureTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
     Cookie testCookie = new Cookie("name1", "value1");
-    testCookie.setVersion(0);
 
-    boolean expectedResult = false;
+    boolean expectedResult = true;
+    testCookie.setSecure(expectedResult);
     boolean result = testCookie.getSecure();
 
     response.addCookie(testCookie);
@@ -544,15 +525,15 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void setSecureVer1Test(@SuppressWarnings("unused") HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
+  public void setAttributeSecureTest(@SuppressWarnings("unused") HttpServletRequest request,
+	      HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
     Cookie testCookie = new Cookie("name1", "value1");
-    testCookie.setVersion(1);
 
-    boolean expectedResult = false;
+    boolean expectedResult = true;
+    testCookie.setAttribute("secure", EMPTY_STRING);
     boolean result = testCookie.getSecure();
 
     response.addCookie(testCookie);
@@ -567,13 +548,35 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void setValueVer0Test(@SuppressWarnings("unused") HttpServletRequest request,
+  public void setAttributeSecureInvalidTest(@SuppressWarnings("unused") HttpServletRequest request,
+	      HttpServletResponse response) throws IOException {
+
+    PrintWriter pw = response.getWriter();
+    boolean passed = false;
+    Cookie testCookie = new Cookie("name1", "value1");
+
+    boolean expectedResult = false;
+    testCookie.setAttribute("secure", "other");
+    boolean result = testCookie.getSecure();
+
+    response.addCookie(testCookie);
+    if (result != expectedResult) {
+      passed = false;
+      pw.println("getSecure() returned an incorrect result ");
+      pw.println("Expected = " + expectedResult + " ");
+      pw.println("Actual = |" + result + "| ");
+    } else {
+      passed = true;
+    }
+    ServletTestUtil.printResult(pw, passed);
+  }
+
+  public void setValueTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     boolean passed = false;
     Cookie testCookie = new Cookie("name1", "value1");
-    testCookie.setVersion(0);
 
     String expectedResult = "value2";
     testCookie.setValue(expectedResult);
@@ -597,36 +600,7 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void setValueVer1Test(@SuppressWarnings("unused") HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-
-    PrintWriter pw = response.getWriter();
-    boolean passed = false;
-    Cookie testCookie = new Cookie("name1", "value1");
-    testCookie.setVersion(1);
-
-    String expectedResult = "value2";
-    testCookie.setValue(expectedResult);
-    String result = testCookie.getValue();
-
-    response.addCookie(testCookie);
-    if (result != null) {
-      if (!result.equals(expectedResult)) {
-        passed = false;
-        pw.println(
-            "setValue(" + expectedResult + ") did not set the value properly");
-        pw.println("Expected = " + expectedResult + " ");
-        pw.println("Actual = |" + result + "| ");
-      } else {
-        passed = true;
-      }
-    } else {
-      passed = false;
-      pw.println("getValue() returned a null result ");
-    }
-    ServletTestUtil.printResult(pw, passed);
-  }
-
+  @Deprecated
   public void setVersionVer0Test(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
@@ -652,8 +626,10 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
+  @Deprecated
   public void setVersionVer1Test(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
+
     PrintWriter pw = response.getWriter();
     boolean passed = false;
     Cookie testCookie = new Cookie("name1", "value1");
@@ -734,5 +710,128 @@ public class TestServlet extends HttpTCKServlet {
       pw.println("getAttributes() returned a null result ");
     }
     ServletTestUtil.printResult(pw, passed);
+  }
+
+  public void getHttpOnlyTest(@SuppressWarnings("unused") HttpServletRequest request,
+	      HttpServletResponse response) throws IOException {
+
+    PrintWriter pw = response.getWriter();
+    boolean passed = false;
+    Cookie testCookie = new Cookie("name1", "value1");
+
+    boolean expectedResult = false;
+    boolean result = testCookie.getSecure();
+
+    response.addCookie(testCookie);
+    if (result != expectedResult) {
+      passed = false;
+      pw.println("getSecure() returned an incorrect result");
+      pw.println("Expected = " + expectedResult + " ");
+      pw.println("Actual = |" + result + "| ");
+    } else {
+      passed = true;
+    }
+    ServletTestUtil.printResult(pw, passed);
+  }
+
+  public void getAttributeHttpOnlyTest(@SuppressWarnings("unused") HttpServletRequest request,
+	      HttpServletResponse response) throws IOException {
+
+    PrintWriter pw = response.getWriter();
+    boolean passed = false;
+    Cookie testCookie = new Cookie("name1", "value1");
+
+    String result = testCookie.getAttribute("secure");
+
+    response.addCookie(testCookie);
+    if (result != null) {
+      passed = false;
+      pw.println("getAttribute(\"Secure\") returned non-null result");
+      pw.println("Actual = |" + result + "| ");
+    } else {
+      passed = true;
+    }
+    ServletTestUtil.printResult(pw, passed);
+  }
+
+  public void setHttpOnlyTest(@SuppressWarnings("unused") HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+
+    PrintWriter pw = response.getWriter();
+    boolean passed = false;
+    Cookie testCookie = new Cookie("name1", "value1");
+
+    boolean expectedResult = true;
+    testCookie.setSecure(expectedResult);
+    boolean result = testCookie.getSecure();
+
+    response.addCookie(testCookie);
+    if (result != expectedResult) {
+      passed = false;
+      pw.println("getSecure() returned an incorrect result ");
+      pw.println("Expected = " + expectedResult + " ");
+      pw.println("Actual = |" + result + "| ");
+    } else {
+      passed = true;
+    }
+    ServletTestUtil.printResult(pw, passed);
+  }
+
+  public void setAttributeHttpOnlyTest(@SuppressWarnings("unused") HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+
+    PrintWriter pw = response.getWriter();
+    boolean passed = false;
+    Cookie testCookie = new Cookie("name1", "value1");
+
+    boolean expectedResult = true;
+    testCookie.setAttribute("secure", EMPTY_STRING);
+    boolean result = testCookie.getSecure();
+
+    response.addCookie(testCookie);
+    if (result != expectedResult) {
+      passed = false;
+      pw.println("getSecure() returned an incorrect result ");
+      pw.println("Expected = " + expectedResult + " ");
+      pw.println("Actual = |" + result + "| ");
+    } else {
+      passed = true;
+    }
+    ServletTestUtil.printResult(pw, passed);
+  }
+
+  public void setAttributeHttpOnlyInvalidTest(@SuppressWarnings("unused") HttpServletRequest request,
+	      HttpServletResponse response) throws IOException {
+
+    PrintWriter pw = response.getWriter();
+    boolean passed = false;
+    Cookie testCookie = new Cookie("name1", "value1");
+
+    boolean expectedResult = false;
+    testCookie.setAttribute("secure", "other");
+    boolean result = testCookie.getSecure();
+
+    response.addCookie(testCookie);
+    if (result != expectedResult) {
+      passed = false;
+      pw.println("getSecure() returned an incorrect result ");
+      pw.println("Expected = " + expectedResult + " ");
+      pw.println("Actual = |" + result + "| ");
+    } else {
+      passed = true;
+    }
+    ServletTestUtil.printResult(pw, passed);
+  }
+
+  public void setPartitionedTest(@SuppressWarnings("unused") HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+
+    PrintWriter pw = response.getWriter();
+    Cookie testCookie = new Cookie("name1", "value1");
+
+    testCookie.setAttribute("Partitioned", EMPTY_STRING);
+    response.addCookie(testCookie);
+
+    ServletTestUtil.printResult(pw, true);
   }
 }

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/TestServlet.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/TestServlet.java
@@ -79,7 +79,7 @@ public class TestServlet extends HttpTCKServlet {
 
   public static String CUSTOM_HEADER_DATE_FORMAT = "yyyy-MM-dd HH:mm";
 
-  public void cloneTest(HttpServletRequest request,
+  public void cloneTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
@@ -101,7 +101,7 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void constructorTest(HttpServletRequest request,
+  public void constructorTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
@@ -125,7 +125,7 @@ public class TestServlet extends HttpTCKServlet {
   }
 
   public void constructorIllegalArgumentExceptionTest(
-      HttpServletRequest request, HttpServletResponse response)
+      @SuppressWarnings("unused") HttpServletRequest request, HttpServletResponse response)
       throws IOException {
     String[] invalidNameValues = { ",test", ";test", " test", "\ttest", "\ntest" };
 
@@ -152,7 +152,7 @@ public class TestServlet extends HttpTCKServlet {
     }
   }
 
-  public void getCommentTest(HttpServletRequest request,
+  public void getCommentTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
     PrintWriter pw = response.getWriter();
     boolean passed = false;
@@ -175,7 +175,7 @@ public class TestServlet extends HttpTCKServlet {
 
   }
 
-  public void getCommentNullTest(HttpServletRequest request,
+  public void getCommentNullTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
     PrintWriter pw = response.getWriter();
     boolean passed = false;
@@ -230,7 +230,7 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void getMaxAgeTest(HttpServletRequest request,
+  public void getMaxAgeTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
@@ -311,7 +311,7 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void getSecureTest(HttpServletRequest request,
+  public void getSecureTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
@@ -415,7 +415,7 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void setDomainTest(HttpServletRequest request,
+  public void setDomainTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
@@ -445,7 +445,7 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void setMaxAgePositiveTest(HttpServletRequest request,
+  public void setMaxAgePositiveTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
@@ -465,7 +465,7 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, true);
   }
 
-  public void setMaxAgeZeroTest(HttpServletRequest request,
+  public void setMaxAgeZeroTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
@@ -478,7 +478,7 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, true);
   }
 
-  public void setMaxAgeNegativeTest(HttpServletRequest request,
+  public void setMaxAgeNegativeTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
@@ -491,7 +491,7 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, true);
   }
 
-  public void setPathTest(HttpServletRequest request,
+  public void setPathTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
@@ -521,7 +521,7 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void setSecureVer0Test(HttpServletRequest request,
+  public void setSecureVer0Test(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
@@ -544,7 +544,7 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void setSecureVer1Test(HttpServletRequest request,
+  public void setSecureVer1Test(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
@@ -567,7 +567,7 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void setValueVer0Test(HttpServletRequest request,
+  public void setValueVer0Test(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
@@ -597,7 +597,7 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void setValueVer1Test(HttpServletRequest request,
+  public void setValueVer1Test(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
@@ -627,7 +627,7 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void setVersionVer0Test(HttpServletRequest request,
+  public void setVersionVer0Test(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     // Expected to be hard-coded to zero
@@ -652,7 +652,7 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void setVersionVer1Test(HttpServletRequest request,
+  public void setVersionVer1Test(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
     PrintWriter pw = response.getWriter();
     boolean passed = false;
@@ -675,7 +675,7 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void setAttributeTest(HttpServletRequest request,
+  public void setAttributeTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
@@ -703,7 +703,7 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void getAttributesTest(HttpServletRequest request,
+  public void getAttributesTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();

--- a/tck/tck-runtime/src/main/java/servlet/tck/pluggability/api/jakarta_servlet_http/cookie/CookieTests.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/pluggability/api/jakarta_servlet_http/cookie/CookieTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates and others.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -13,10 +13,6 @@
  * https://www.gnu.org/software/classpath/license.html.
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
- */
-
-/*
- * $Id:$
  */
 package servlet.tck.pluggability.api.jakarta_servlet_http.cookie;
 
@@ -85,9 +81,9 @@ public class CookieTests extends AbstractTckTest {
 
   /*
    * @testName: constructorTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:434
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Servlet tests constructor method and verify it works;
@@ -100,9 +96,9 @@ public class CookieTests extends AbstractTckTest {
 
   /*
    * @testName: constructorIllegalArgumentExceptionTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:628
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Servlet tests constructor method throws IllegalArgumentException when
@@ -118,9 +114,9 @@ public class CookieTests extends AbstractTckTest {
 
   /*
    * @testName: getCommentTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:436
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Servlet tests method getComment;
@@ -133,9 +129,9 @@ public class CookieTests extends AbstractTckTest {
 
   /*
    * @testName: getCommentNullTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:437
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Servlet tests method getComment when there is no comment;
@@ -148,9 +144,9 @@ public class CookieTests extends AbstractTckTest {
 
   /*
    * @testName: getDomainTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:439
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Client sends a version 0 and 1 cookie to the servlet. Servlet verifies
@@ -158,20 +154,15 @@ public class CookieTests extends AbstractTckTest {
    */
   @Test
   public void getDomainTest() throws Exception {
-    // version 1
-    TEST_PROPS.get().setProperty(REQUEST_HEADERS,
-        "Cookie: $Version=1; name1=value1; $Domain=" + _hostname
-            + "; $Path=" + getContextRoot());
     TEST_PROPS.get().setProperty(APITEST, "getDomainTest");
     invoke();
-
   }
 
   /*
    * @testName: getMaxAgeTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:443
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Servlet tests method getMaxAge;
@@ -184,9 +175,9 @@ public class CookieTests extends AbstractTckTest {
 
   /*
    * @testName: getNameTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:448
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Client sends a version 0 and 1 cookie to a servlet; Servlet tests method
@@ -194,25 +185,17 @@ public class CookieTests extends AbstractTckTest {
    */
   @Test
   public void getNameTest() throws Exception {
-    // version 0 Cookie
     TEST_PROPS.get().setProperty(REQUEST_HEADERS, "Cookie: name1=value1; Domain="
         + _hostname + "; Path=" + getContextRoot());
-    TEST_PROPS.get().setProperty(APITEST, "getNameTest");
-    invoke();
-
-    // version 1 Cookie
-    TEST_PROPS.get().setProperty(REQUEST_HEADERS,
-        "Cookie: $Version=1; name1=value1; $Domain=" + _hostname
-            + "; $Path=" + getContextRoot());
     TEST_PROPS.get().setProperty(APITEST, "getNameTest");
     invoke();
   }
 
   /*
    * @testName: getPathTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:445
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Client sends a version 1 cookie to a servlet; Servlet tests method getPath
@@ -220,18 +203,15 @@ public class CookieTests extends AbstractTckTest {
    */
   @Test
   public void getPathTest() throws Exception {
-    TEST_PROPS.get().setProperty(REQUEST_HEADERS,
-        "Cookie: $Version=1; name1=value1; $Domain=" + _hostname
-            + "; $Path=" + getContextRoot());
     TEST_PROPS.get().setProperty(APITEST, "getPathTest");
     invoke();
   }
 
   /*
    * @testName: getSecureTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:447
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Servlet tests method Cookie.getSecure;
@@ -242,11 +222,17 @@ public class CookieTests extends AbstractTckTest {
     invoke();
   }
 
+  @Test
+  public void getAttributeSecureTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "getAttributeSecureTest");
+    invoke();
+  }
+
   /*
    * @testName: getValueTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:450
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Client sends a version 0 and 1 cookie to a servlet; Servlet tests method
@@ -254,24 +240,25 @@ public class CookieTests extends AbstractTckTest {
    */
   @Test
   public void getValueTest() throws Exception {
-    // version 0 Cookie
     TEST_PROPS.get().setProperty(REQUEST_HEADERS, "Cookie: name1=value1; Domain="
         + _hostname + "; Path=" + getContextRoot());
     TEST_PROPS.get().setProperty(APITEST, "getValueTest");
     invoke();
-    // version 1 Cookie
-    TEST_PROPS.get().setProperty(REQUEST_HEADERS,
-        "Cookie: $Version=1; name1=value1; $Domain=" + _hostname
-            + "; $Path=" + getContextRoot());
-    TEST_PROPS.get().setProperty(APITEST, "getValueTest");
+  }
+
+  @Test
+  public void getValueQuotedTest() throws Exception {
+    TEST_PROPS.get().setProperty(REQUEST_HEADERS, "Cookie: name1=\"value1\"; Domain="
+            + _hostname + "; Path=" + getContextRoot());
+    TEST_PROPS.get().setProperty(APITEST, "getValueQuotedTest");
     invoke();
   }
 
   /*
    * @testName: getVersionTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:451
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Client sends a version 0 and 1 cookie to a servlet; Servlet tests method
@@ -279,24 +266,15 @@ public class CookieTests extends AbstractTckTest {
    */
   @Test
   public void getVersionTest() throws Exception {
-    // version 0 Cookie
-    TEST_PROPS.get().setProperty(REQUEST_HEADERS, "Cookie: name1=value1; Domain="
-        + _hostname + "; Path=" + getContextRoot());
-    TEST_PROPS.get().setProperty(APITEST, "getVersionVer0Test");
-    invoke();
-    // version 1 Cookie
-    TEST_PROPS.get().setProperty(REQUEST_HEADERS,
-        "Cookie: $Version=1; name1=value1; $Domain=" + _hostname
-            + "; $Path=" + getContextRoot());
-    TEST_PROPS.get().setProperty(APITEST, "getVersionVer1Test");
+    TEST_PROPS.get().setProperty(APITEST, "getVersionTest");
     invoke();
   }
 
   /*
    * @testName: setDomainTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:438
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Servlet tests method Cookie.setDomain
@@ -309,9 +287,9 @@ public class CookieTests extends AbstractTckTest {
 
   /*
    * @testName: setMaxAgePositiveTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:440
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Servlet create Cookie and sets values using Cookie.setMaxAge(2) Cookie is
@@ -319,11 +297,9 @@ public class CookieTests extends AbstractTckTest {
    */
   @Test
   public void setMaxAgePositiveTest() throws Exception {
-    // version 0 cookie
     String testName = "setMaxAgePositiveTest";
     HttpResponse response = null;
     String dateHeader = null;
-    int index = -1;
     Date expiryDate = null;
     String body = null;
 
@@ -336,21 +312,18 @@ public class CookieTests extends AbstractTckTest {
       dateHeader = response.getResponseHeader("testDate")
               .orElseThrow(() -> new NullPointerException("testDate is empty")).getValue();
 
-      logger.trace("Found {} set-cookie entry", response.getResponseHeaders("Set-Cookie").size());
+      logger.trace("Found {} set-cookie entry", String.valueOf(response.getResponseHeaders("Set-Cookie").size()));
 
       boolean foundcookie = false;
       List<String> cookiesHeaders = response.getResponseHeaders("Set-Cookie");
-
       int i = 0;
       while (i < cookiesHeaders.size()) {
         if(logger.isTraceEnabled()) {
-          logger.trace("Checking set-cookiei {}, {}", i, cookiesHeaders.get(i));
+          logger.trace("Checking set-cookiei {}:{}", String.valueOf(i), cookiesHeaders.get(i));
         }
         List<HttpCookie> cookies = HttpCookie.parse(cookiesHeaders.get(i));
-
-        Optional<HttpCookie> optionalHttpCookie =
-                cookies.stream().filter(httpCookie -> httpCookie.getName().equals("name1")).findFirst();
-
+        Optional<HttpCookie> optionalHttpCookie = cookies.stream().filter(httpCookie -> httpCookie.getName().equals("name1"))
+                .findFirst();
         if (optionalHttpCookie.isPresent()) {
           HttpCookie httpCookie = optionalHttpCookie.get();
           expiryDate = new Date(httpCookie.getMaxAge());
@@ -365,7 +338,7 @@ public class CookieTests extends AbstractTckTest {
         throw new Exception("The test cookie was not located in the response");
       }
     } catch (Throwable t) {
-      throw new Exception("Exception occurred:" + t);
+      throw new Exception("Exception occurred:" + t, t);
     }
 
     // put expiry date into GMT
@@ -384,16 +357,16 @@ public class CookieTests extends AbstractTckTest {
       throw new Exception("Exception occurred: " + t);
     }
 
-    if (body.indexOf(Data.PASSED) == -1) {
+    if (body == null || !body.contains(Data.PASSED)) {
       throw new Exception("The string: " + Data.PASSED + " not found in response");
     }
   }
 
   /*
    * @testName: setMaxAgeZeroTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:442
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Servlet create Cookie and sets values using Cookie.setMaxAge(0) Cookie is
@@ -402,15 +375,83 @@ public class CookieTests extends AbstractTckTest {
   @Test
   public void setMaxAgeZeroTest() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "setMaxAgeZeroTest");
-    TEST_PROPS.get().setProperty(EXPECTED_HEADERS, "Set-Cookie:name1=value1##Max-Age=0");
+    // RFC 6265 - server should only send +ve values for Max-Age
+    TEST_PROPS.get().setProperty(EXPECTED_HEADERS, "Set-Cookie:name1=value1##!Max-Age##Expires=");
     invoke();
+  }
+
+  @Test
+  public void setMaxAgeZeroDateTest() throws Exception {
+    String testName = "setMaxAgeZeroTest";
+    HttpResponse response = null;
+    Date expiryDate = null;
+    String body = null;
+
+    HttpExchange request = new HttpExchange("GET " + getContextRoot() + "/"
+            + getServletName() + "?testname=" + testName + " HTTP/1.1", _hostname,
+            _port);
+
+    try {
+      response = request.execute();
+
+      logger.trace("Found {} set-cookie entry", String.valueOf(response.getResponseHeaders("Set-Cookie").size()));
+
+      boolean foundcookie = false;
+      List<String> cookiesHeaders = response.getResponseHeaders("Set-Cookie");
+      int i = 0;
+      while (i < cookiesHeaders.size()) {
+        logger.trace("Checking set-cookie i {}:{}", String.valueOf(i), cookiesHeaders.get(i));
+        List<HttpCookie> cookies = HttpCookie.parse(cookiesHeaders.get(i));
+        Optional<HttpCookie> optionalHttpCookie = cookies.stream().filter(httpCookie -> httpCookie.getName().equals("name1"))
+                .findFirst();
+        if (optionalHttpCookie.isPresent()) {
+          HttpCookie httpCookie = optionalHttpCookie.get();
+          expiryDate = new Date(httpCookie.getMaxAge());
+          body = response.getResponseBodyAsString();
+          foundcookie = true;
+          break;
+        }
+        i++;
+      }
+
+      if (!foundcookie)
+        throw new Exception("The test cookie was not located in the response");
+    } catch (Throwable t) {
+      throw new Exception("Exception occurred:" + t, t);
+    }
+
+    // put expiry date into GMT
+    SimpleDateFormat sdf = new SimpleDateFormat(TestServlet.CUSTOM_HEADER_DATE_FORMAT);
+    sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+    String resultStringDate = sdf.format(expiryDate);
+
+    try {
+      Date resultDate = sdf.parse(resultStringDate);
+      /*
+       * RFC 6265 does not allow the server to send a Max-Age attribute with value zero. The implication from the client
+       * requirements is that an expires header should be sent with the earliest representable date. There is a fair
+       * amount of room for interpretation in all of this so check that whatever has been sent is in the past.
+       */
+      Date expectedDate = new Date(System.currentTimeMillis());
+      if (resultDate.after(expectedDate)) {
+        throw new Exception("The expiry date was incorrect, expected ="
+                + expectedDate + ", result = " + resultDate);
+      }
+    } catch (Throwable t) {
+      throw new Exception("Exception occurred: " + t);
+    }
+
+    if (body == null || !body.contains(Data.PASSED)) {
+      throw new Exception("The string: " + Data.PASSED + " not found in response");
+    }
+
   }
 
   /*
    * @testName: setMaxAgeNegativeTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:441
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Servlet create Cookie and sets values using Cookie.setMaxAge(-1) Cookie is
@@ -425,10 +466,26 @@ public class CookieTests extends AbstractTckTest {
   }
 
   /*
+   * @testName: setPathTest
+   *
+   * @assertion_ids: Servlet:JAVADOC:444
+   *
+   * @test_Strategy: Servlet tests method and returns result to client
+   */
+  @Test
+  public void setPathTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "setPathTest");
+    // The path is set in the Servlet so need to check for that, not the current context path
+    TEST_PROPS.get().setProperty(EXPECTED_HEADERS,
+            "Set-Cookie:Path=\"/servlet_jsh_cookie_web\"");
+    invoke();
+  }
+
+  /*
    * @testName: setSecureTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:446
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Servlet create Version 0 and Version 1 Cookie and sets values using
@@ -436,17 +493,27 @@ public class CookieTests extends AbstractTckTest {
    */
   @Test
   public void setSecureTest() throws Exception {
-    TEST_PROPS.get().setProperty(APITEST, "setSecureVer0Test");
+    TEST_PROPS.get().setProperty(APITEST, "setSecureTest");
     invoke();
-    TEST_PROPS.get().setProperty(APITEST, "setSecureVer1Test");
+  }
+
+  @Test
+  public void setAttributeSecureTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "setAttributeSecureTest");
+    invoke();
+  }
+
+  @Test
+  public void setAttributeSecureInvalidTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "setAttributeSecureInvalidTest");
     invoke();
   }
 
   /*
    * @testName: setValueTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:449
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Servlet create Version 0 and Version 1 Cookie and sets values using
@@ -454,17 +521,15 @@ public class CookieTests extends AbstractTckTest {
    */
   @Test
   public void setValueTest() throws Exception {
-    TEST_PROPS.get().setProperty(APITEST, "setValueVer0Test");
-    invoke();
-    TEST_PROPS.get().setProperty(APITEST, "setValueVer1Test");
+    TEST_PROPS.get().setProperty(APITEST, "setValueTest");
     invoke();
   }
 
   /*
    * @testName: setVersionTest
-   * 
+   *
    * @assertion_ids: Servlet:JAVADOC:452
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Servlet create Version 0 and Version 1 Cookie and sets values using
@@ -480,9 +545,9 @@ public class CookieTests extends AbstractTckTest {
 
   /*
    * @testName: setAttributeTest
-   * 
+   *
    * @assertion_ids:
-   * 
+   *
    * @test_Strategy: Create a web application with no web.xml and one fragment;
    * Define everything in web-fragment.xml; Package everything in the fragment;
    * Servlet tests method Cookie.setAttribute
@@ -492,17 +557,54 @@ public class CookieTests extends AbstractTckTest {
     TEST_PROPS.get().setProperty(APITEST, "setAttributeTest");
     invoke();
   }
-  
+
   /*
    * @testName: getAttributesTest
-   * 
+   *
    * @assertion_ids:
-   * 
+   *
    * @test_Strategy: Servlet tests method and returns result to client
    */
   @Test
   public void getAttributesTest() throws Exception {
     TEST_PROPS.get().setProperty(APITEST, "getAttributesTest");
+    invoke();
+  }
+
+  @Test
+  public void getHttpOnlyTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "getHttpOnlyTest");
+    invoke();
+  }
+
+  @Test
+  public void getAttributeHttpOnlyTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "getAttributeHttpOnlyTest");
+    invoke();
+  }
+
+  @Test
+  public void setHttpOnlyTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "setHttpOnlyTest");
+    invoke();
+  }
+
+  @Test
+  public void setAttributeHttpOnlyTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "setAttributeHttpOnlyTest");
+    invoke();
+  }
+
+  @Test
+  public void setAttributeHttpOnlyInvalidTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "setAttributeHttpOnlyInvalidTest");
+    invoke();
+  }
+
+  @Test
+  public void setPartitionedTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "setPartitionedTest");
+    TEST_PROPS.get().setProperty(EXPECTED_HEADERS, "Set-Cookie:name1=value1##Partitioned##!Partitioned=");
     invoke();
   }
 }


### PR DESCRIPTION
This TCK update contains the following changes:
- code clean-up to remove all IDE warnings
- remove of tests explicitly testing RFC2109 syntax
- additional tests to check secure attribute via `[g|s]etSecure()` `[g|s]etAttribute()`
- new test for cookie values with quotes (RFC 6265 says the quotes are part of the value)
- version tests are more explicit that `setVersion()` is a NO-OP
- checks that server doesn't send `Max-Age=0`
- adds check that server sends `Expires` value in the past for `Max-Age=0`
- new tests for `HttpOnly`

The tests pass with the current Tomcat 11.0.x development branch although a few minor changes were required to achieve that.

These changes definitely need time for review but we are also up against the deadline for the release. I'll try and wait a full week before merging - assuming there are no objections.