### PR TITLE
We need to include slf4j librairies for remote managed container as it is not avaible as embeded container

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Building
 --------
 Prerequisites:
 
-* JDK 11+
-* Maven 3.5.4+
+* JDK 17+
+* Maven 3.9.0+
 
 Run the build: 
 
@@ -22,7 +22,4 @@ Run the build:
 The build runs copyright check and generates the jar, sources-jar and javadoc-jar by default.
 The API jar is built in /api/target.
 
-Checking findbugs
------------------
-`mvn -DskipTests -Dfindbugs.threshold=Low findbugs:findbugs`
 

--- a/tck/README.md
+++ b/tck/README.md
@@ -1,6 +1,6 @@
 # Jakarta Servlet
 
-This repository contains the code for Jakarta Servle TCK
+This repository contains the code for Jakarta Servlet TCK
 
 About Jakarta Servlet TCK
 -------------------------
@@ -10,7 +10,7 @@ Building
 --------
 Prerequisites:
 
-* JDK 11+
+* JDK 17+
 * Maven 3.9.0+
 
 Run the build: 
@@ -41,6 +41,10 @@ This will be achieved by adding a dependency within your surefire configuration
           <servlet.tck.support.crossContext>false</servlet.tck.support.crossContext>
           <!-- if the servlet container doesn't support optional http2 push -->  
           <servlet.tck.support.http2Push>false</servlet.tck.support.http2Push>
+          <!-- 
+          the slf4j impl to include within the deployed wars, default value is org.slf4j:slf4j-simple
+          -->  
+          <servlet.tck.slf4jimpl>org.slf4j:slf4j-simple</servlet.tck.slf4jimpl>  
         </systemProperties>          
       </configuration>
     </plugin>

--- a/tck/tck-runtime/src/main/java/servlet/tck/common/servlets/CommonServlets.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/common/servlets/CommonServlets.java
@@ -1,5 +1,6 @@
 package servlet.tck.common.servlets;
 
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import servlet.tck.api.common.sharedfiles.HSessionAttributeListener;
 import servlet.tck.api.common.sharedfiles.HSessionListener;
 import servlet.tck.common.response.HttpResponseTestServlet;
@@ -11,8 +12,11 @@ import servlet.tck.common.util.StaticLog;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 
+import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class CommonServlets {
 
@@ -21,17 +25,17 @@ public class CommonServlets {
     private final JavaArchive[] javaArchives;
 
     private CommonServlets() {
-        List<JavaArchive> archives = new ArrayList<>();
-//
-//        File[] files = Maven.configureResolver().workOffline().loadPomFromFile("pom.xml")
-//                .resolve("org.slf4j:slf4j-simple")
-//                .withTransitivity()
-//                .asFile();
-//        List<JavaArchive> slf4jJars =
-//                Arrays.stream(files).map(file -> ShrinkWrap.createFromZipFile(JavaArchive.class, file))
-//                        .collect(Collectors.toList());
-//
-//        //archives.addAll(slf4jJars);
+
+        String slf4jImplCanonicalForm = System.getProperty("servlet.tck.slf4jimpl", "org.slf4j:slf4j-simple");
+        File[] files = Maven.configureResolver().workOffline().loadPomFromFile("pom.xml")
+                .resolve(slf4jImplCanonicalForm)
+                .withTransitivity()
+                .asFile();
+        List<JavaArchive> slf4jJars =
+                Arrays.stream(files).map(file -> ShrinkWrap.createFromZipFile(JavaArchive.class, file))
+                        .collect(Collectors.toList());
+
+        List<JavaArchive> archives = new ArrayList<>(slf4jJars);
 
         archives.add(ShrinkWrap.create(JavaArchive.class, "common-servlets.jar")
                 .addClasses(GenericCheckTestResultServlet.class, GenericTCKServlet.class, RequestTestServlet.class,


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
