### PR TITLE
Use method that returns boolean rather than Boolean

### DIFF
--- a/api/src/main/java/jakarta/servlet/http/Cookie.java
+++ b/api/src/main/java/jakarta/servlet/http/Cookie.java
@@ -75,7 +75,7 @@ public class Cookie implements Cloneable, Serializable {
     private static final ResourceBundle lStrings = ResourceBundle.getBundle(LSTRING_FILE);
 
     static {
-        boolean enforced = Boolean.valueOf(System.getProperty("org.glassfish.web.rfc2109_cookie_names_enforced", "true"));
+        boolean enforced = Boolean.parseBoolean(System.getProperty("org.glassfish.web.rfc2109_cookie_names_enforced", "true"));
 
         if (enforced) {
             TSPECIALS = "/()<>@,;:\\\"[]?={} \t";


### PR DESCRIPTION
Given that we want a boolean, use the method that returns one.

Should be uncontroversial. I'll merge tomorrow unless there are objections.