### PR TITLE
Fix #525 FlushBufferTest

### DIFF
--- a/tck/tck-runtime/src/main/java/servlet/tck/spec/httpservletresponse/HttpServletResponseTests.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/spec/httpservletresponse/HttpServletResponseTests.java
@@ -79,9 +79,18 @@ public class HttpServletResponseTests extends AbstractTckTest {
    * setIntHeader to set header; 4. Attempt to write
    * additional bytes, expecting an exception to confirm the output stream
    * is closed; 5. Verify a 200 response without the header value set.
+   * 6. Repeat the test to check that the expected exception was thrown
+   * after the first request.
    */
   @Test
   public void flushBufferOnContentLengthTest() throws Exception {
+    TEST_PROPS.get().setProperty(SAVE_STATE, "true");
+    TEST_PROPS.get().setProperty(UNEXPECTED_HEADERS, "header1: 12345");
+    TEST_PROPS.get().setProperty(REQUEST, "GET " + getContextRoot() + "/"
+        + getServletName() + "?testname=" + "flushBufferOnContentLengthTest" + " HTTP/1.1");
+    invoke();
+
+    TEST_PROPS.get().setProperty(USE_SAVED_STATE, "true");
     TEST_PROPS.get().setProperty(UNEXPECTED_HEADERS, "header1: 12345");
     TEST_PROPS.get().setProperty(REQUEST, "GET " + getContextRoot() + "/"
         + getServletName() + "?testname=" + "flushBufferOnContentLengthTest" + " HTTP/1.1");
@@ -97,10 +106,17 @@ public class HttpServletResponseTests extends AbstractTckTest {
    * content; 2. Write some bytes and flush the response; 3. Write
    * remaining bytes to the expected content length; 4. Attempt to write
    * additional bytes, expecting an exception to confirm the output stream
-   * is closed; 5. Verify a 200 response.
+   * is closed; 5. Verify a 200 response; 6. Repeat the test to check that
+   * the expected exception was thrown after the first request.
    */
   @Test
   public void flushBufferOnContentLengthCommittedTest() throws Exception {
+    TEST_PROPS.get().setProperty(SAVE_STATE, "true");
+    TEST_PROPS.get().setProperty(REQUEST, "GET " + getContextRoot() + "/"
+        + getServletName() + "?testname=" + "flushBufferOnContentLengthCommittedTest" + " HTTP/1.1");
+    invoke();
+
+    TEST_PROPS.get().setProperty(USE_SAVED_STATE, "true");
     TEST_PROPS.get().setProperty(REQUEST, "GET " + getContextRoot() + "/"
         + getServletName() + "?testname=" + "flushBufferOnContentLengthCommittedTest" + " HTTP/1.1");
     invoke();

--- a/tck/tck-runtime/src/main/java/servlet/tck/spec/httpservletresponse/HttpServletResponseTests.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/spec/httpservletresponse/HttpServletResponseTests.java
@@ -70,19 +70,39 @@ public class HttpServletResponseTests extends AbstractTckTest {
   }
 
   /*
-   * @testName: flushBufferTest
+   * @testName: flushBufferOnContentLengthTest
    *
    * @assertion_ids: Servlet:SPEC:32; Servlet:SPEC:33; Servlet:SPEC:42.2;
    *
    * @test_Strategy: 1. First call setContentLength to set the length of
-   * content; 2. Then write to the buffer to fill up the buffer. 2. Call
-   * setIntHeader to set header 3. Verify that the header value is not set,
+   * content; 2. Write bytes to the expected content length; 3. Call
+   * setIntHeader to set header; 4. Attempt to write
+   * additional bytes, expecting an exception to confirm the output stream
+   * is closed; 5. Verify a 200 response without the header value set.
    */
   @Test
-  public void flushBufferTest() throws Exception {
+  public void flushBufferOnContentLengthTest() throws Exception {
     TEST_PROPS.get().setProperty(UNEXPECTED_HEADERS, "header1: 12345");
     TEST_PROPS.get().setProperty(REQUEST, "GET " + getContextRoot() + "/"
-        + getServletName() + "?testname=" + "flushBufferTest" + " HTTP/1.1");
+        + getServletName() + "?testname=" + "flushBufferOnContentLengthTest" + " HTTP/1.1");
+    invoke();
+  }
+
+  /*
+   * @testName: flushBufferOnContentLengthCommittedTest
+   *
+   * @assertion_ids: Servlet:SPEC:32; Servlet:SPEC:33; Servlet:SPEC:42.2;
+   *
+   * @test_Strategy: 1. First call setContentLength to set the length of
+   * content; 2. Write some bytes and flush the response; 3. Write
+   * remaining bytes to the expected content length; 4. Attempt to write
+   * additional bytes, expecting an exception to confirm the output stream
+   * is closed; 5. Verify a 200 response.
+   */
+  @Test
+  public void flushBufferOnContentLengthCommittedTest() throws Exception {
+    TEST_PROPS.get().setProperty(REQUEST, "GET " + getContextRoot() + "/"
+        + getServletName() + "?testname=" + "flushBufferOnContentLengthCommittedTest" + " HTTP/1.1");
     invoke();
   }
 

--- a/tck/tck-runtime/src/main/java/servlet/tck/spec/httpservletresponse/HttpTestServlet.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/spec/httpservletresponse/HttpTestServlet.java
@@ -30,6 +30,7 @@ import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
+import jakarta.servlet.http.HttpSession;
 import servlet.tck.common.servlets.HttpTCKServlet;
 
 import jakarta.servlet.ServletException;
@@ -47,6 +48,11 @@ public class HttpTestServlet extends HttpTCKServlet {
 
   public void flushBufferOnContentLengthTest(HttpServletRequest request,
       HttpServletResponse response) throws ServletException, IOException {
+    HttpSession session = request.getSession(true);
+    Object illegalStateException = session.getAttribute("IllegalStateException");
+    if (illegalStateException instanceof IllegalStateException)
+      throw (IllegalStateException)illegalStateException;
+
     int size = 40;
     response.setContentLength(size);
 
@@ -61,12 +67,17 @@ public class HttpTestServlet extends HttpTCKServlet {
 
     try {
       out.write(fill);
-      throw new IllegalStateException("write did not fail");
-    } catch (Throwable ignored) {}
+      session.setAttribute("IllegalStateException", new IllegalStateException("write did not fail"));
+    } catch (IOException ignored) {}
   }
 
   public void flushBufferOnContentLengthCommittedTest(HttpServletRequest request,
-         HttpServletResponse response) throws ServletException, IOException {
+      HttpServletResponse response) throws ServletException, IOException {
+    HttpSession session = request.getSession(true);
+    Object illegalStateException = session.getAttribute("IllegalStateException");
+    if (illegalStateException instanceof IllegalStateException)
+        throw (IllegalStateException)illegalStateException;
+
     int size = 40;
     response.setContentLength(size);
 
@@ -81,8 +92,8 @@ public class HttpTestServlet extends HttpTCKServlet {
 
     try {
       out.write(fill);
-      throw new IllegalStateException("write did not fail");
-    } catch (Throwable ignored) {}
+      session.setAttribute("IllegalStateException", new IllegalStateException("write did not fail"));
+    } catch (IOException ignored) {}
   }
 
   public void sendErrorCommitTest(HttpServletRequest request,


### PR DESCRIPTION
Replace the disputed test (that tests poorly defined behaviour of a bad servlet) with two tests that check the accepted behaviour of a well written servlet.

Once there is an accepted interpretation of the behaviour for the bad servlet, additional tests can be added to check that.