### PR TITLE
Add jakarta.servlet.error.method to Table 10-1 and organize

### DIFF
--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -5506,8 +5506,8 @@ a `RequestDispatcher.forward` to the error resource had been performed.
 |Request Attributes
 |Type
 
-|`jakarta.servlet.error.status_code`
-|`java.lang.Integer`
+|`jakarta.servlet.error.exception`
+|`java.lang.Throwable`
 
 |`jakarta.servlet.error.exception_type`
 |`java.lang.Class`
@@ -5515,17 +5515,20 @@ a `RequestDispatcher.forward` to the error resource had been performed.
 |`jakarta.servlet.error.message`
 |`java.lang.String`
 
-|`jakarta.servlet.error.exception`
-|`java.lang.Throwable`
-
-|`jakarta.servlet.error.request_uri`
+|`jakarta.servlet.error.method`
 |`java.lang.String`
 
 |`jakarta.servlet.error.query_string`
 |`java.lang.String`
 
+|`jakarta.servlet.error.request_uri`
+|`java.lang.String`
+
 |`jakarta.servlet.error.servlet_name`
 |`java.lang.String`
+
+|`jakarta.servlet.error.status_code`
+|`java.lang.Integer`
 |===
 
 These attributes allow the servlet to generate


### PR DESCRIPTION
for #682

I'll backport this change to the 6.1 branch once it is merged into the main branch.

1) Adding the `jakarta.servlet.error.method` to the request attribute table. 
2) Organize the request attribute table