### PR TITLE
Drop outdated sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,3 @@ About Jakarta Servlet
 ---------------------
 Jakarta Servlet defines a server-side API for handling HTTP requests and responses.
 
-Building
---------
-Prerequisites:
-
-* JDK8+
-* Maven 3.0.3+
-
-Run the build: 
-
-`mvn install`
-
-The build runs copyright check and generates the jar, sources-jar and javadoc-jar by default.
-The API jar is built in /api/target.
-
-Checking findbugs
------------------
-`mvn -DskipTests -Dfindbugs.threshold=Low findbugs:findbugs`
-

--- a/spec/README.md
+++ b/spec/README.md
@@ -3,20 +3,3 @@ Jakarta Servlet Specification
 
 This project generates the Jakarta Servlet Specification.
 
-Building
---------
-
-Prerequisites:
-
-* JDK8+
-* Maven 3.0.3+
-
-Run the full build:
-
-`mvn install`
-
-Locate the html files:
-- `target/generated-docs/servlet-spec-<version>.html`
-
-Locate the PDF files:
-- `target/generated-docs/servlet-spec-<version>.pdf`


### PR DESCRIPTION
Given this branch is not regularly maintained I believe it's better to leave these parts out.
The (remaining) links to repo with more current README is enough.