### PR TITLE
[734] Add the AddFilterString to the deployment.

### DIFF
--- a/tck/tck-runtime/src/main/java/servlet/tck/pluggability/api/jakarta_servlet/registration/RegistrationTests.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/pluggability/api/jakarta_servlet/registration/RegistrationTests.java
@@ -21,6 +21,7 @@ package servlet.tck.pluggability.api.jakarta_servlet.registration;
 
 import servlet.tck.api.jakarta_servlet.registration.TestListener;
 import servlet.tck.api.jakarta_servlet.registration.TestServlet;
+import servlet.tck.api.jakarta_servlet.servletcontext30.AddFilterString;
 import servlet.tck.api.jakarta_servlet.servletcontext30.AddServletString;
 import servlet.tck.api.jakarta_servlet.servletcontext30.AddServletClass;
 import servlet.tck.api.jakarta_servlet.servletcontext30.AddServletNotFound;
@@ -56,7 +57,7 @@ public class RegistrationTests extends AbstractTckTest {
   public static WebArchive getTestArchive() throws Exception {
     JavaArchive javaArchive = ShrinkWrap.create(JavaArchive.class, "fragment-1.jar")
             .addClasses(TestServlet1.class, RequestListener1.class, AddServletString.class, AddServletClass.class,
-                    AddFilterClass.class, CreateServlet.class, CreateFilter.class, AddServletNotFound.class,
+                    AddFilterString.class, AddFilterClass.class, CreateServlet.class, CreateFilter.class, AddServletNotFound.class,
                     AddFilterNotFound.class, BadServlet.class, BadFilter.class, BadListener.class)
             .addAsResource(RegistrationTests.class.getResource("servlet_plu_registration_web-fragment.xml"),
                     "META-INF/web-fragment.xml");


### PR DESCRIPTION
resolves #734 

I'm not sure how this would go into 6.1, but we'd need it there as well. 

I've tested this on WildFly and it passes:
```
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.116 s -- in servlet.tck.pluggability.api.jakarta_servlet.registration.RegistrationTests
16:12:02,709 INFO  [org.jboss.as.server] (management-handler-thread - 1) WFLYSRV0272: Suspending server
16:12:02,711 INFO  [org.jboss.as.ejb3] (management-handler-thread - 1) WFLYEJB0493: Jakarta Enterprise Beans subsystem suspension complete
16:12:02,712 INFO  [org.jboss.as.server] (Management Triggered Shutdown) WFLYSRV0241: Shutting down in response to management operation 'shutdown'
16:12:02,716 INFO  [org.jboss.as.connector.subsystems.datasources] (MSC service thread 1-5) WFLYJCA0010: Unbound data source [java:jboss/datasources/ExampleDS]
16:12:02,722 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-6) WFLYUT0019: Host default-host stopping
16:12:02,724 INFO  [org.jboss.as.mail.extension] (MSC service thread 1-8) WFLYMAIL0002: Unbound mail session [java:jboss/mail/Default]
16:12:02,724 INFO  [org.jboss.as.connector.deployers.jdbc] (MSC service thread 1-8) WFLYJCA0019: Stopped Driver service with driver-name = h2
16:12:02,725 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-1) WFLYUT0008: Undertow HTTPS listener https suspending
16:12:02,725 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-1) WFLYUT0007: Undertow HTTPS listener https stopped, was bound to 127.0.0.1:8443
16:12:02,726 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-7) WFLYUT0008: Undertow HTTP listener default suspending
16:12:02,728 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-7) WFLYUT0007: Undertow HTTP listener default stopped, was bound to 127.0.0.1:8080
16:12:02,732 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-5) WFLYUT0004: Undertow 2.3.18.Final stopping
16:12:02,752 INFO  [org.jboss.as] (MSC service thread 1-8) WFLYSRV0050: WildFly Preview 34.0.0.Final (WildFly Core 26.0.1.Final) stopped in 36ms
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jar:3.3.0:jar (default-jar) @ tck-runner ---
[WARNING] JAR will be empty - no content was marked for inclusion!
[INFO] Building jar: /home/jperkins/projects/wildfly/wildfly-tck-runners/servlet-tck/tck-runner/target/tck-runner-1.0.0.Final-SNAPSHOT.jar
[INFO] 
[INFO] --- source:3.3.0:jar-no-fork (attach-sources) @ tck-runner ---
[INFO] No sources in project. Archive not created.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  25.050 s
[INFO] Finished at: 2024-10-24T16:12:03-07:00
[INFO] ------------------------------------------------------------------------
```