### PR TITLE
Revert "Fix #525 FlushBufferTest"

### DIFF
--- a/.github/ISSUE_TEMPLATE/tck_challenge.md
+++ b/.github/ISSUE_TEMPLATE/tck_challenge.md
@@ -1,0 +1,21 @@
+---
+name: TCK Challenge
+about: Create a TCK Challenge
+title: ''
+labels: 'challenge'
+assignees: ''
+
+---
+
+**Challenged tests**
+List the challenged tests with the fully qualified classnames and then the test methods, e.g.
+ee.jakarta.tck.faces.test.javaee7.multiFieldValidation.Spec1IT#testFailingPreconditionsNotAfterAllInputComponents
+
+**TCK Version**
+Specify the version of the TCK, e.g. Jakarta Faces 4.0.x
+
+**Description**
+A clear and concise description of why you think the tests are wrong.
+
+**Additional context**
+Add any other context about the challenge here.

--- a/.github/ISSUE_TEMPLATE/tck_challenge.md
+++ b/.github/ISSUE_TEMPLATE/tck_challenge.md
@@ -9,10 +9,10 @@ assignees: ''
 
 **Challenged tests**
 List the challenged tests with the fully qualified classnames and then the test methods, e.g.
-ee.jakarta.tck.faces.test.javaee7.multiFieldValidation.Spec1IT#testFailingPreconditionsNotAfterAllInputComponents
+servlet.tck.api.jakarta_servlet.asynccontext#dispatchZeroArgTest()
 
 **TCK Version**
-Specify the version of the TCK, e.g. Jakarta Faces 4.0.x
+Specify the version of the TCK, e.g. Jakarta Servlet 6.1.x
 
 **Description**
 A clear and concise description of why you think the tests are wrong.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,21 @@ version: 2
 updates:
   - package-ecosystem: "maven"
     directory: "/"
+    target-branch: "master"
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "master"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "/"
+    target-branch: "6.1.x"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "6.1.x"
     schedule:
       interval: "weekly"

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.10.3</version>
+            <version>5.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -128,7 +128,7 @@
                 <plugin>
                     <groupId>net.revelc.code.formatter</groupId>
                     <artifactId>formatter-maven-plugin</artifactId>
-                    <version>2.23.0</version>
+                    <version>2.24.1</version>
                     <configuration>
                         <configFile>${project.basedir}/etc/config/ee4j-eclipse-formatting.xml</configFile>
                     </configuration>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -177,7 +177,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.0</version>
             </plugin>
 
             <!-- Checks copyright / license headers -->        

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -136,7 +136,7 @@
                 <plugin>
                     <groupId>net.revelc.code</groupId>
                     <artifactId>impsort-maven-plugin</artifactId>
-                    <version>1.11.0</version>
+                    <version>1.12.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -136,7 +136,7 @@
                 <plugin>
                     <groupId>net.revelc.code</groupId>
                     <artifactId>impsort-maven-plugin</artifactId>
-                    <version>1.10.0</version>
+                    <version>1.11.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -177,7 +177,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.5.2</version>
             </plugin>
 
             <!-- Checks copyright / license headers -->        

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.10.2</version>
+            <version>5.10.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>jakarta.servlet</groupId>
     <artifactId>jakarta.servlet-api</artifactId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.1-SNAPSHOT</version>
 
     <name>Jakarta Servlet</name>
     <url>https://projects.eclipse.org/projects/ee4j.servlet</url>
@@ -219,7 +219,7 @@
                         <supportedProjectType>jar</supportedProjectType>
                     </supportedProjectTypes>
                     <instructions>
-                        <Bundle-Version>6.1.0</Bundle-Version>
+                        <Bundle-Version>6.1.1</Bundle-Version>
                         <Bundle-SymbolicName>jakarta.servlet-api</Bundle-SymbolicName>
                         <Bundle-Description>
                             Jakarta Servlet 6.1

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.10.2</version>
+            <version>5.10.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>jakarta.servlet</groupId>
     <artifactId>jakarta.servlet-api</artifactId>
-    <version>6.1.1-SNAPSHOT</version>
+    <version>6.2.0-SNAPSHOT</version>
 
     <name>Jakarta Servlet</name>
     <url>https://projects.eclipse.org/projects/ee4j.servlet</url>
@@ -219,13 +219,13 @@
                         <supportedProjectType>jar</supportedProjectType>
                     </supportedProjectTypes>
                     <instructions>
-                        <Bundle-Version>6.1.1</Bundle-Version>
+                        <Bundle-Version>6.2.0</Bundle-Version>
                         <Bundle-SymbolicName>jakarta.servlet-api</Bundle-SymbolicName>
                         <Bundle-Description>
-                            Jakarta Servlet 6.1
+                            Jakarta Servlet 6.2
                         </Bundle-Description>
                         <Extension-Name>jakarta.servlet</Extension-Name>
-                        <Specification-Version>6.1</Specification-Version>
+                        <Specification-Version>6.2</Specification-Version>
                         <Specification-Vendor>Eclipse Foundation</Specification-Vendor>
                         <Implementation-Version>${project.version}</Implementation-Version>
                         <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>

--- a/api/src/main/java/jakarta/servlet/http/Cookie.java
+++ b/api/src/main/java/jakarta/servlet/http/Cookie.java
@@ -75,7 +75,7 @@ public class Cookie implements Cloneable, Serializable {
     private static final ResourceBundle lStrings = ResourceBundle.getBundle(LSTRING_FILE);
 
     static {
-        boolean enforced = Boolean.valueOf(System.getProperty("org.glassfish.web.rfc2109_cookie_names_enforced", "true"));
+        boolean enforced = Boolean.parseBoolean(System.getProperty("org.glassfish.web.rfc2109_cookie_names_enforced", "true"));
 
         if (enforced) {
             TSPECIALS = "/()<>@,;:\\\"[]?={} \t";

--- a/api/src/main/java/jakarta/servlet/http/HttpServletRequestWrapper.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletRequestWrapper.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
- * Copyright (c) 1997, 2023 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2024 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/http/HttpServletRequestWrapper.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletRequestWrapper.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2023 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
@@ -284,7 +285,7 @@ public class HttpServletRequestWrapper extends ServletRequestWrapper implements 
     }
 
     /**
-     * The default behavior of this method is to call login on the wrapped request object.
+     * The default behavior of this method is to call logout on the wrapped request object.
      *
      * @since Servlet 3.0
      */

--- a/api/src/main/java/jakarta/servlet/http/HttpServletResponse.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2024 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -250,6 +250,17 @@ public interface HttpServletResponse extends ServletResponse {
      * @since Servlet 6.1
      */
     void sendRedirect(String location, int sc, boolean clearBuffer) throws IOException;
+
+    /**
+     * Sends a 103 response to the client using the current response headers. This method does not commit the response and
+     * may be called multiple times before the response is committed. The current response headers may include some headers
+     * that have been added automatcially by the container.
+     * <p>
+     * This method has no effect if called after the response has been committed.
+     *
+     * @since Servlet 6.2
+     */
+    void sendEarlyHints();
 
     /**
      * Sets a response header with the given name and date-value. The date is specified in terms of milliseconds since the
@@ -507,6 +518,14 @@ public interface HttpServletResponse extends ServletResponse {
      * Status code (101) indicating the server is switching protocols according to Upgrade header.
      */
     int SC_SWITCHING_PROTOCOLS = 101;
+
+    /**
+     * Status code (103) indicating that the server is likely to send a final response containing the headers present in
+     * this informational response.
+     *
+     * @since Servlet 6.2
+     */
+    int SC_EARLY_HINTS = 103;
 
     /**
      * Status code (200) indicating the request succeeded normally.

--- a/api/src/main/java/jakarta/servlet/http/HttpServletResponseWrapper.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletResponseWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2024 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -139,6 +139,16 @@ public class HttpServletResponseWrapper extends ServletResponseWrapper implement
     @Override
     public void sendRedirect(String location, int sc, boolean clearBuffer) throws IOException {
         this._getHttpServletResponse().sendRedirect(location, sc, clearBuffer);
+    }
+
+    /**
+     * The default behavior of this method is to call sendEarlyHints() on the wrapped response object.
+     *
+     * @since Servlet 6.2
+     */
+    @Override
+    public void sendEarlyHints() {
+        this._getHttpServletResponse().sendEarlyHints();
     }
 
     /**

--- a/api/src/test/java/ee/jakarta/servlet/MockServletConfig.java
+++ b/api/src/test/java/ee/jakarta/servlet/MockServletConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,8 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package jakarta.servlet;
+package ee.jakarta.servlet;
 
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;

--- a/api/src/test/java/ee/jakarta/servlet/MockServletContext.java
+++ b/api/src/test/java/ee/jakarta/servlet/MockServletContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,8 +14,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package jakarta.servlet;
+package ee.jakarta.servlet;
 
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterRegistration;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRegistration;
+import jakarta.servlet.SessionCookieConfig;
+import jakarta.servlet.SessionTrackingMode;
 import jakarta.servlet.descriptor.JspConfigDescriptor;
 import java.io.InputStream;
 import java.net.MalformedURLException;

--- a/api/src/test/java/ee/jakarta/servlet/MockServletOutputStream.java
+++ b/api/src/test/java/ee/jakarta/servlet/MockServletOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,8 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package jakarta.servlet;
+package ee.jakarta.servlet;
 
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;

--- a/api/src/test/java/ee/jakarta/servlet/MockServletRequest.java
+++ b/api/src/test/java/ee/jakarta/servlet/MockServletRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,8 +14,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package jakarta.servlet;
+package ee.jakarta.servlet;
 
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletConnection;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;

--- a/api/src/test/java/ee/jakarta/servlet/MockServletResponse.java
+++ b/api/src/test/java/ee/jakarta/servlet/MockServletResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,8 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package jakarta.servlet;
+package ee.jakarta.servlet;
 
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.ServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;

--- a/api/src/test/java/ee/jakarta/servlet/http/CanonicalUriPathTest.java
+++ b/api/src/test/java/ee/jakarta/servlet/http/CanonicalUriPathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package jakarta.servlet.http;
+package ee.jakarta.servlet.http;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;

--- a/api/src/test/java/ee/jakarta/servlet/http/CookieTest.java
+++ b/api/src/test/java/ee/jakarta/servlet/http/CookieTest.java
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package jakarta.servlet.http;
+package ee.jakarta.servlet.http;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;

--- a/api/src/test/java/ee/jakarta/servlet/http/HttpServletTest.java
+++ b/api/src/test/java/ee/jakarta/servlet/http/HttpServletTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package jakarta.servlet.http;
+package ee.jakarta.servlet.http;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
@@ -22,10 +22,13 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import jakarta.servlet.MockServletConfig;
-import jakarta.servlet.MockServletOutputStream;
+import ee.jakarta.servlet.MockServletConfig;
+import ee.jakarta.servlet.MockServletOutputStream;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Enumeration;

--- a/api/src/test/java/ee/jakarta/servlet/http/MockHttpServletRequest.java
+++ b/api/src/test/java/ee/jakarta/servlet/http/MockHttpServletRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,11 +14,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package jakarta.servlet.http;
+package ee.jakarta.servlet.http;
 
-import jakarta.servlet.MockServletRequest;
+import ee.jakarta.servlet.MockServletRequest;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpUpgradeHandler;
+import jakarta.servlet.http.Part;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.Collection;

--- a/api/src/test/java/ee/jakarta/servlet/http/MockHttpServletResponse.java
+++ b/api/src/test/java/ee/jakarta/servlet/http/MockHttpServletResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,9 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package jakarta.servlet.http;
+package ee.jakarta.servlet.http;
 
-import jakarta.servlet.MockServletResponse;
+import ee.jakarta.servlet.MockServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collection;
 

--- a/api/src/test/java/ee/jakarta/servlet/http/MockHttpServletResponse.java
+++ b/api/src/test/java/ee/jakarta/servlet/http/MockHttpServletResponse.java
@@ -74,6 +74,11 @@ public class MockHttpServletResponse extends MockServletResponse implements Http
     }
 
     @Override
+    public void sendEarlyHints() {
+
+    }
+
+    @Override
     public void setDateHeader(String name, long date) {
 
     }

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>jakarta.servlet</groupId>
     <artifactId>servlet-parent</artifactId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Servlet Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>jakarta.servlet</groupId>
     <artifactId>servlet-parent</artifactId>
-    <version>6.1.1-SNAPSHOT</version>
+    <version>6.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Servlet Parent</name>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -36,7 +36,7 @@
         <maven.site.skip>true</maven.site.skip>
         <asciidoctorj.version>3.0.0</asciidoctorj.version>
         <asciidoctorj.pdf.version>2.3.19</asciidoctorj.pdf.version>
-        <jruby.version>9.4.8.0</jruby.version>
+        <jruby.version>9.4.9.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -36,7 +36,7 @@
         <maven.site.skip>true</maven.site.skip>
         <asciidoctorj.version>3.0.0</asciidoctorj.version>
         <asciidoctorj.pdf.version>2.3.19</asciidoctorj.pdf.version>
-        <jruby.version>9.3.15.0</jruby.version>
+        <jruby.version>9.4.8.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation.
+    Copyright (c) 2019, 2024 Contributors to the Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,7 +34,7 @@
     <properties>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
-        <asciidoctorj.version>2.5.13</asciidoctorj.version>
+        <asciidoctorj.version>3.0.0</asciidoctorj.version>
         <asciidoctorj.pdf.version>2.3.18</asciidoctorj.pdf.version>
         <jruby.version>9.3.15.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
@@ -90,6 +90,8 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
+                <!-- Override parent until parent is updated -->
+                <version>3.0.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.jruby</groupId>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -36,7 +36,7 @@
         <maven.site.skip>true</maven.site.skip>
         <asciidoctorj.version>2.5.13</asciidoctorj.version>
         <asciidoctorj.pdf.version>2.3.17</asciidoctorj.pdf.version>
-        <jruby.version>9.3.14.0</jruby.version>
+        <jruby.version>9.3.15.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.servlet</groupId>
         <artifactId>servlet-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>servlet-spec</artifactId>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>jakarta.servlet</groupId>
         <artifactId>servlet-parent</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>servlet-spec</artifactId>
-    <version>6.1-SNAPSHOT</version>
+    <version>6.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Servlet Specification</name>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -35,7 +35,7 @@
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
         <asciidoctorj.version>2.5.13</asciidoctorj.version>
-        <asciidoctorj.pdf.version>2.3.15</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>2.3.17</asciidoctorj.pdf.version>
         <jruby.version>9.3.14.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -36,7 +36,7 @@
         <maven.site.skip>true</maven.site.skip>
         <asciidoctorj.version>2.5.13</asciidoctorj.version>
         <asciidoctorj.pdf.version>2.3.15</asciidoctorj.pdf.version>
-        <jruby.version>9.3.13.0</jruby.version>
+        <jruby.version>9.3.14.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -91,7 +91,7 @@
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <!-- Override parent until parent is updated -->
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.jruby</groupId>

--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -8579,7 +8579,9 @@ Jakarta Servlet {spec-version} specification developed under the Jakarta EE Work
 
 === Changes Since Jakarta Servlet 6.1
 
-TBD.
+link:https://github.com/eclipse-ee4j/servlet-api/issues/542[Issue 542]::
+Add support for RFC 8297 (Early Hints) via a new method `sendEarlyHints()` on
+the `HttpServletResponse` 
 
 === Changes Since Jakarta Servlet 6.0
 

--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -1,6 +1,6 @@
 :xrefstyle: full
-:spec-version: 6.1
-:spec-version-underscore: 6_1
+:spec-version: 6.2
+:spec-version-underscore: 6_2
 
 :sectnums!:
 :figure-caption!:
@@ -8576,6 +8576,10 @@ for Dependency Injection" of the Jakarta EE Platform 11 specification.
 
 This document is the final release of the
 Jakarta Servlet {spec-version} specification developed under the Jakarta EE Working Group.
+
+=== Changes Since Jakarta Servlet 6.1
+
+TBD.
 
 === Changes Since Jakarta Servlet 6.0
 

--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -6532,11 +6532,11 @@ public @interface HttpMethodConstraint {
 |===
 |Element
 |Description
-|value
 |Default
 
-
-
+|value
+|The HTTP protocol method name
+|
 
 |`emptyRoleSemantic`
 |The default authorization semantic that

--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -5506,8 +5506,8 @@ a `RequestDispatcher.forward` to the error resource had been performed.
 |Request Attributes
 |Type
 
-|`jakarta.servlet.error.status_code`
-|`java.lang.Integer`
+|`jakarta.servlet.error.exception`
+|`java.lang.Throwable`
 
 |`jakarta.servlet.error.exception_type`
 |`java.lang.Class`
@@ -5515,17 +5515,20 @@ a `RequestDispatcher.forward` to the error resource had been performed.
 |`jakarta.servlet.error.message`
 |`java.lang.String`
 
-|`jakarta.servlet.error.exception`
-|`java.lang.Throwable`
-
-|`jakarta.servlet.error.request_uri`
+|`jakarta.servlet.error.method`
 |`java.lang.String`
 
 |`jakarta.servlet.error.query_string`
 |`java.lang.String`
 
+|`jakarta.servlet.error.request_uri`
+|`java.lang.String`
+
 |`jakarta.servlet.error.servlet_name`
 |`java.lang.String`
+
+|`jakarta.servlet.error.status_code`
+|`java.lang.Integer`
 |===
 
 These attributes allow the servlet to generate

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -111,7 +111,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.9.0.Final</version>
+                <version>1.9.1.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -125,7 +125,7 @@
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-bom</artifactId>
-                <version>3.3.0</version>
+                <version>3.3.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -125,7 +125,7 @@
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-bom</artifactId>
-                <version>3.3.1</version>
+                <version>3.3.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -58,7 +58,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.10.2</version>
+                <version>5.10.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>servlet-tck</artifactId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Servlet TCK</name>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -53,6 +53,52 @@
         <module>tck-dist</module>
     </modules>
 
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.4.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.3.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.13.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.4.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.1.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.1.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>3.7.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>servlet-tck</artifactId>
-    <version>6.1.1-SNAPSHOT</version>
+    <version>6.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Servlet TCK</name>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -83,7 +83,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.1.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -88,7 +88,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.1.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -104,7 +104,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.10.3</version>
+                <version>5.11.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/tck/tck-dist/pom.xml
+++ b/tck/tck-dist/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>servlet-tck</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>servlet-tck-dist</artifactId>

--- a/tck/tck-dist/pom.xml
+++ b/tck/tck-dist/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>servlet-tck</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>servlet-tck-dist</artifactId>

--- a/tck/tck-dist/pom.xml
+++ b/tck/tck-dist/pom.xml
@@ -53,7 +53,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.7.1</version>
                 <executions>
                     <execution>
                         <id>distribution</id>

--- a/tck/tck-dist/src/main/resources/artifact-install.sh
+++ b/tck/tck-dist/src/main/resources/artifact-install.sh
@@ -20,7 +20,7 @@
 if [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
   VERSION="$1"
 else
-  VERSION="6.1.0"
+  VERSION="6.2.0"
 fi
 
 JAKARTAEE_VERSION="11.0.0-M1"

--- a/tck/tck-docs/ServletJavadocAssertions.html
+++ b/tck/tck-docs/ServletJavadocAssertions.html
@@ -25,7 +25,7 @@
 <body bgcolor="white">
 <br>
 <CENTER>
-<h2>Jakarta Servlet<br>Servlet - 6.1<br>
+<h2>Jakarta Servlet<br>Servlet - 6.2<br>
 				JavaDoc Assertion Detail 
 			</h2>
 </CENTER>

--- a/tck/tck-docs/ServletSpecAssertions.html
+++ b/tck/tck-docs/ServletSpecAssertions.html
@@ -25,7 +25,7 @@
 <body bgcolor="white">
 <br>
 <CENTER>
-<h2>Jakarta Servlet<br>Servlet - 6.1<br>
+<h2>Jakarta Servlet<br>Servlet - 6.2<br>
 				Specification Assertion Detail 
 			</h2>
 </CENTER>

--- a/tck/tck-docs/ServletTCK6.2-ReleaseNotes.html
+++ b/tck/tck-docs/ServletTCK6.2-ReleaseNotes.html
@@ -35,24 +35,24 @@ th {  background-color: #eeeeee; padding-left: 2pt; padding-right: 2pt;}
 </style></head>
   <body>
     <div align="center">
-      <h1>Jakarta EE Servlet Technology Compatibility Kit, Version 6.1<br>
+      <h1>Jakarta EE Servlet Technology Compatibility Kit, Version 6.2<br>
         <em class="emphasize">Release Notes, May 2024</em></h1>
     </div>
     <h2><a name="kit_contents">Kit Contents</a></h2>
-    <p>The Jakarta EE Servlet, Version 6.1 Technology Compatibility Kit (TCK)
+    <p>The Jakarta EE Servlet, Version 6.2 Technology Compatibility Kit (TCK)
       includes the following items:</p>
     <ul>
       <li><strong>Jakarta EE Servlet TCK tests signature, API, and End-to-End
           tests:</strong></li>
       <ul type="square">
         <li><strong>Signature test</strong> that checks that all of the public
-          APIs are supported in the Jakarta EE Servlet Version 6.1
+          APIs are supported in the Jakarta EE Servlet Version 6.2
           implementation that is being tested</li>
         <li><strong>API tests</strong> for the public APIs under the <code>jakarta.servlet</code>,
           <code>jakarta.servlet.annotation</code>, <code>jakarta.servlet.descriptor</code> and
           <code>jakarta.servlet.http</code>  packages</li>
         <li><strong>Specification tests</strong> for testable assertions
-          required by the Jakarta EE Servlet 6.1 Specification</li>
+          required by the Jakarta EE Servlet 6.2 Specification</li>
       </ul>
     </ul>
     <hr>
@@ -72,16 +72,16 @@ th {  background-color: #eeeeee; padding-left: 2pt; padding-right: 2pt;}
       <li>Ubuntu Linux 22.04</li>
     </ul>
     <p>The Jakarta EE Servlet TCK tests have been run against the following
-      Jakarta EE Servlet 6.1 Compatible Implementations:</p>
+      Jakarta EE Servlet 6.2 Compatible Implementations:</p>
     <ul>
       <li>Apache Tomcat 11</li>
     </ul>
     <hr>
     <h2><a name="install_setup_run">Installing, Setting Up, and Running the
         JavaTM API for Servlet TCK</a></h2>
-    <p>Refer to the <a href="html-usersguide/title.html" title="Jakarta EE Servlet TCK 6.1 User's Guide (HTML)">Jakarta
-        EE Servlet Technology Compatibility Kit, Version 6.1 User's Guide</a>
-      (or <a href="./pdf-usersguide/Jakarta-Servlet-TCK-Users-Guide.pdf" title="Jakarta EE Servlet TCK 6.1 User's Guide (PDF)">PDF</a>)
+    <p>Refer to the <a href="html-usersguide/title.html" title="Jakarta EE Servlet TCK 6.2 User's Guide (HTML)">Jakarta
+        EE Servlet Technology Compatibility Kit, Version 6.2 User's Guide</a>
+      (or <a href="./pdf-usersguide/Jakarta-Servlet-TCK-Users-Guide.pdf" title="Jakarta EE Servlet TCK 6.2 User's Guide (PDF)">PDF</a>)
       for complete instructions on installing, setting up, and running the
       Jakarta EE Servlet TCK. </p>
     <hr>

--- a/tck/tck-docs/index.html
+++ b/tck/tck-docs/index.html
@@ -32,26 +32,26 @@ h4 {  font-style: italic; color: #000099}
 
     alink="#0000ff">
     <div align="Center">
-      <h1>Welcome to the Jakarta EE Servlet TCK, Version 6.1</h1>
+      <h1>Welcome to the Jakarta EE Servlet TCK, Version 6.2</h1>
       <h2> <span class="emphasize">Your Starting Point</span></h2>
     </div>
     <hr>
-    <h2>Guide to Jakarta EE Servlet TCK 6.1 Documentation</h2>
-    <p>The Jakarta EE Servlet TCK 6.1 documentation includes the following:</p>
+    <h2>Guide to Jakarta EE Servlet TCK 6.2 Documentation</h2>
+    <p>The Jakarta EE Servlet TCK 6.2 documentation includes the following:</p>
     <ul>
-      <li>The <em><a href="ServletTCK6.1-ReleaseNotes.html">Jakarta EE
+      <li>The <em><a href="ServletTCK6.2-ReleaseNotes.html">Jakarta EE
             Servlet TCK Release Notes</a></em> provides the information on the
         test harness, the test suite and the platforms tested.
         <ul>
           <li>The Release Notes updates may be available from the Jakarta EE
-            Servlet specification web site: <a href="https://jakarta.ee/specifications/servlet/6.1/">https://jakarta.ee/specifications/servlet/6.1/</a></li>
+            Servlet specification web site: <a href="https://jakarta.ee/specifications/servlet/6.2/">https://jakarta.ee/specifications/servlet/6.2/</a></li>
         </ul>
       </li>
-      <li> The <a href="./html-usersguide/title.html" title="Jakarta EE Servlet TCK 6.1 User's Guide (HTML)">Jakarta
-          EE Servlet Technology Compatibility Kit, Version 6.1 User's Guide</a>
-        (or <a href="./pdf-usersguide/Jakarta-Servlet-TCK-Users-Guide.pdf" title="Jakarta EE Servlet TCK 6.1 User's Guide (PDF)">PDF</a>)
+      <li> The <a href="./html-usersguide/title.html" title="Jakarta EE Servlet TCK 6.2 User's Guide (HTML)">Jakarta
+          EE Servlet Technology Compatibility Kit, Version 6.2 User's Guide</a>
+        (or <a href="./pdf-usersguide/Jakarta-Servlet-TCK-Users-Guide.pdf" title="Jakarta EE Servlet TCK 6.2 User's Guide (PDF)">PDF</a>)
         provides the information that you need to install, set up, and run the
-        Jakarta EE Servlet TCK, Version 6.1. In addition, the guide provides
+        Jakarta EE Servlet TCK, Version 6.2. In addition, the guide provides
         the rules you must comply with to pass the Jakarta EE Servlet TCK.</li>
       <li>The <a href="./ServletJavadocAssertions.html">Javadoc
           Assertion List</a> lists all the javadoc assertions that are tested by

--- a/tck/tck-docs/userguide/pom.xml
+++ b/tck/tck-docs/userguide/pom.xml
@@ -28,7 +28,7 @@
     <groupId>jakarta.tck</groupId>
     <artifactId>servlet-tck-docs</artifactId>
     <packaging>pom</packaging>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.1-SNAPSHOT</version>
     <name>Eclipse Foundation Technology Compatibility Kit User's Guide for Jakarta Servlet for Jakarta EE, Release 6.1</name>
 
     <properties>

--- a/tck/tck-docs/userguide/pom.xml
+++ b/tck/tck-docs/userguide/pom.xml
@@ -28,8 +28,8 @@
     <groupId>jakarta.tck</groupId>
     <artifactId>servlet-tck-docs</artifactId>
     <packaging>pom</packaging>
-    <version>6.1.1-SNAPSHOT</version>
-    <name>Eclipse Foundation Technology Compatibility Kit User's Guide for Jakarta Servlet for Jakarta EE, Release 6.1</name>
+    <version>6.2.0-SNAPSHOT</version>
+    <name>Eclipse Foundation Technology Compatibility Kit User's Guide for Jakarta Servlet for Jakarta EE, Release 6.2</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tck/tck-docs/userguide/src/main/jbake/content/attributes.conf
+++ b/tck/tck-docs/userguide/src/main/jbake/content/attributes.conf
@@ -1,12 +1,12 @@
 :TechnologyFullName: Jakarta Servlet
 :TechnologyShortName: Servlet
 :LegacyAcronym: Java Servlet		   
-:TechnologyVersion: 6.1
+:TechnologyVersion: 6.2
 :ReleaseDate: May 2024
 :CopyrightDates: 2017, 2024
 :TechnologyRI: Tomcat 11.0
 :TechnologyRIURL: https://tomcat.apache.org/download-11.cgi
-:SpecificationURL: https://jakarta.ee/specifications/servlet/6.1/
+:SpecificationURL: https://jakarta.ee/specifications/servlet/6.2/
 :TCKInquiryList: mailto:servlet-dev@eclipse.org[servlet-dev@eclipse.org]
 :SpecificationInquiryList: mailto:servlet-dev@eclipse.org[servlet-dev@eclipse.org]
 :techID: Servlet
@@ -26,7 +26,7 @@
 :MavenVersion: 3.8.5+
 :JakartaEEVersion: 11
 :excludeListFileName: docs/TCK-Exclude-List.txt
-:TCKPackageName: jakarta-servlet-tck-6.1.0.zip
+:TCKPackageName: jakarta-servlet-tck-6.2.0.zip
 // Directory names used in examples in using.adoc.
 :sigTestDirectoryExample: servlet/tck/signature
 :singleTestDirectoryExample: servlet/tck/api/jakarta_servlet/asynccontext

--- a/tck/tck-runtime/pom.xml
+++ b/tck/tck-runtime/pom.xml
@@ -33,7 +33,7 @@
     <name>Jakarta Servlet TCK Runtime</name>
 
     <properties>
-        <shrinkwrap-resolver.version>3.3.0</shrinkwrap-resolver.version>
+        <shrinkwrap-resolver.version>3.3.1</shrinkwrap-resolver.version>
         <servlet.api.version>6.2.0-SNAPSHOT</servlet.api.version>
         <sigtest.version>2.3</sigtest.version>
     </properties>

--- a/tck/tck-runtime/pom.xml
+++ b/tck/tck-runtime/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>servlet-tck</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>servlet-tck-runtime</artifactId>
@@ -34,7 +34,7 @@
 
     <properties>
         <shrinkwrap-resolver.version>3.3.0</shrinkwrap-resolver.version>
-        <servlet.api.version>6.1.1-SNAPSHOT</servlet.api.version>
+        <servlet.api.version>6.2.0-SNAPSHOT</servlet.api.version>
     </properties>
 
     <dependencies>

--- a/tck/tck-runtime/pom.xml
+++ b/tck/tck-runtime/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>servlet-tck</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>servlet-tck-runtime</artifactId>
@@ -34,7 +34,7 @@
 
     <properties>
         <shrinkwrap-resolver.version>3.3.0</shrinkwrap-resolver.version>
-        <servlet.api.version>6.1.0-SNAPSHOT</servlet.api.version>
+        <servlet.api.version>6.1.1-SNAPSHOT</servlet.api.version>
     </properties>
 
     <dependencies>

--- a/tck/tck-runtime/pom.xml
+++ b/tck/tck-runtime/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.16.1</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/tck/tck-runtime/pom.xml
+++ b/tck/tck-runtime/pom.xml
@@ -35,6 +35,7 @@
     <properties>
         <shrinkwrap-resolver.version>3.3.0</shrinkwrap-resolver.version>
         <servlet.api.version>6.2.0-SNAPSHOT</servlet.api.version>
+        <sigtest.version>2.3</sigtest.version>
     </properties>
 
     <dependencies>
@@ -52,7 +53,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>2.3</version>
+            <version>${sigtest.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
@@ -119,7 +120,7 @@
             <plugin>
                 <groupId>jakarta.tck</groupId>
                 <artifactId>sigtest-maven-plugin</artifactId>
-                <version>2.3</version>
+                <version>${sigtest.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/tck/tck-runtime/pom.xml
+++ b/tck/tck-runtime/pom.xml
@@ -33,7 +33,7 @@
     <name>Jakarta Servlet TCK Runtime</name>
 
     <properties>
-        <shrinkwrap-resolver.version>3.3.1</shrinkwrap-resolver.version>
+        <shrinkwrap-resolver.version>3.3.2</shrinkwrap-resolver.version>
         <servlet.api.version>6.2.0-SNAPSHOT</servlet.api.version>
         <sigtest.version>2.3</sigtest.version>
     </properties>

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/CookieTests.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/CookieTests.java
@@ -540,10 +540,18 @@ public class CookieTests extends AbstractTckTest {
     invoke();
   }
 
+  /*
+   * @testName: setEmptyAttributeTest
+   *
+   * @assertion_ids:
+   *
+   * @test_Strategy: Servlet sets a cookie that includes an empty attribute. Ensures that the attribute is present and
+   *                 that there is no '=' after the attribute name.
+   */
   @Test
-  public void setPartitionedTest() throws Exception {
-    TEST_PROPS.get().setProperty(APITEST, "setPartitionedTest");
-    TEST_PROPS.get().setProperty(EXPECTED_HEADERS, "Set-Cookie:name1=value1##Partitioned##!Partitioned=");
+  public void setEmptyAttributeTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "setEmptyAttributeTest");
+    TEST_PROPS.get().setProperty(EXPECTED_HEADERS, "Set-Cookie:name1=value1##EmptyAttribute##!EmptyAttribute=");
     invoke();
   }
 }

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/TestServlet.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/TestServlet.java
@@ -823,13 +823,13 @@ public class TestServlet extends HttpTCKServlet {
     ServletTestUtil.printResult(pw, passed);
   }
 
-  public void setPartitionedTest(@SuppressWarnings("unused") HttpServletRequest request,
+  public void setEmptyAttributeTest(@SuppressWarnings("unused") HttpServletRequest request,
       HttpServletResponse response) throws IOException {
 
     PrintWriter pw = response.getWriter();
     Cookie testCookie = new Cookie("name1", "value1");
 
-    testCookie.setAttribute("Partitioned", EMPTY_STRING);
+    testCookie.setAttribute("EmptyAttribute", EMPTY_STRING);
     response.addCookie(testCookie);
 
     ServletTestUtil.printResult(pw, true);

--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/TestServlet.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/cookie/TestServlet.java
@@ -720,12 +720,12 @@ public class TestServlet extends HttpTCKServlet {
     Cookie testCookie = new Cookie("name1", "value1");
 
     boolean expectedResult = false;
-    boolean result = testCookie.getSecure();
+    boolean result = testCookie.isHttpOnly();
 
     response.addCookie(testCookie);
     if (result != expectedResult) {
       passed = false;
-      pw.println("getSecure() returned an incorrect result");
+      pw.println("isHttpOnly() returned an incorrect result");
       pw.println("Expected = " + expectedResult + " ");
       pw.println("Actual = |" + result + "| ");
     } else {
@@ -741,12 +741,12 @@ public class TestServlet extends HttpTCKServlet {
     boolean passed = false;
     Cookie testCookie = new Cookie("name1", "value1");
 
-    String result = testCookie.getAttribute("secure");
+    String result = testCookie.getAttribute("httponly");
 
     response.addCookie(testCookie);
     if (result != null) {
       passed = false;
-      pw.println("getAttribute(\"Secure\") returned non-null result");
+      pw.println("getAttribute(\"HttpOnly\") returned non-null result");
       pw.println("Actual = |" + result + "| ");
     } else {
       passed = true;
@@ -762,13 +762,13 @@ public class TestServlet extends HttpTCKServlet {
     Cookie testCookie = new Cookie("name1", "value1");
 
     boolean expectedResult = true;
-    testCookie.setSecure(expectedResult);
-    boolean result = testCookie.getSecure();
+    testCookie.setHttpOnly(expectedResult);
+    boolean result = testCookie.isHttpOnly();
 
     response.addCookie(testCookie);
     if (result != expectedResult) {
       passed = false;
-      pw.println("getSecure() returned an incorrect result ");
+      pw.println("isHttpOnly() returned an incorrect result ");
       pw.println("Expected = " + expectedResult + " ");
       pw.println("Actual = |" + result + "| ");
     } else {
@@ -785,13 +785,13 @@ public class TestServlet extends HttpTCKServlet {
     Cookie testCookie = new Cookie("name1", "value1");
 
     boolean expectedResult = true;
-    testCookie.setAttribute("secure", EMPTY_STRING);
-    boolean result = testCookie.getSecure();
+    testCookie.setAttribute("httponly", EMPTY_STRING);
+    boolean result = testCookie.isHttpOnly();
 
     response.addCookie(testCookie);
     if (result != expectedResult) {
       passed = false;
-      pw.println("getSecure() returned an incorrect result ");
+      pw.println("isHttpOnly() returned an incorrect result ");
       pw.println("Expected = " + expectedResult + " ");
       pw.println("Actual = |" + result + "| ");
     } else {
@@ -808,13 +808,13 @@ public class TestServlet extends HttpTCKServlet {
     Cookie testCookie = new Cookie("name1", "value1");
 
     boolean expectedResult = false;
-    testCookie.setAttribute("secure", "other");
-    boolean result = testCookie.getSecure();
+    testCookie.setAttribute("httponly", "other");
+    boolean result = testCookie.isHttpOnly();
 
     response.addCookie(testCookie);
     if (result != expectedResult) {
       passed = false;
-      pw.println("getSecure() returned an incorrect result ");
+      pw.println("isHttpOnly() returned an incorrect result ");
       pw.println("Expected = " + expectedResult + " ");
       pw.println("Actual = |" + result + "| ");
     } else {

--- a/tck/tck-runtime/src/main/java/servlet/tck/pluggability/api/jakarta_servlet/registration/RegistrationTests.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/pluggability/api/jakarta_servlet/registration/RegistrationTests.java
@@ -21,6 +21,7 @@ package servlet.tck.pluggability.api.jakarta_servlet.registration;
 
 import servlet.tck.api.jakarta_servlet.registration.TestListener;
 import servlet.tck.api.jakarta_servlet.registration.TestServlet;
+import servlet.tck.api.jakarta_servlet.servletcontext30.AddFilterString;
 import servlet.tck.api.jakarta_servlet.servletcontext30.AddServletString;
 import servlet.tck.api.jakarta_servlet.servletcontext30.AddServletClass;
 import servlet.tck.api.jakarta_servlet.servletcontext30.AddServletNotFound;
@@ -56,7 +57,7 @@ public class RegistrationTests extends AbstractTckTest {
   public static WebArchive getTestArchive() throws Exception {
     JavaArchive javaArchive = ShrinkWrap.create(JavaArchive.class, "fragment-1.jar")
             .addClasses(TestServlet1.class, RequestListener1.class, AddServletString.class, AddServletClass.class,
-                    AddFilterClass.class, CreateServlet.class, CreateFilter.class, AddServletNotFound.class,
+                    AddFilterString.class, AddFilterClass.class, CreateServlet.class, CreateFilter.class, AddServletNotFound.class,
                     AddFilterNotFound.class, BadServlet.class, BadFilter.class, BadListener.class)
             .addAsResource(RegistrationTests.class.getResource("servlet_plu_registration_web-fragment.xml"),
                     "META-INF/web-fragment.xml");

--- a/tck/tck-runtime/src/main/java/servlet/tck/pluggability/api/jakarta_servlet_http/cookie/CookieTests.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/pluggability/api/jakarta_servlet_http/cookie/CookieTests.java
@@ -602,9 +602,9 @@ public class CookieTests extends AbstractTckTest {
   }
 
   @Test
-  public void setPartitionedTest() throws Exception {
-    TEST_PROPS.get().setProperty(APITEST, "setPartitionedTest");
-    TEST_PROPS.get().setProperty(EXPECTED_HEADERS, "Set-Cookie:name1=value1##Partitioned##!Partitioned=");
+  public void setEmptyAttributeTest() throws Exception {
+    TEST_PROPS.get().setProperty(APITEST, "setEmptyAttributeTest");
+    TEST_PROPS.get().setProperty(EXPECTED_HEADERS, "Set-Cookie:name1=value1##EmptyAttribute##!EmptyAttribute=");
     invoke();
   }
 }

--- a/tck/tck-runtime/src/main/java/servlet/tck/signature/SigTestDriver.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/signature/SigTestDriver.java
@@ -53,26 +53,6 @@ public class SigTestDriver extends SignatureTestDriver {
 
   private static final String EXCLUDE_JDK_CLASS_FLAG = "-IgnoreJDKClass";
 
-  private static String[] excludeJdkClasses = {
-          "java.util.Map",
-          "java.lang.Object",
-          "java.io.ByteArrayInputStream",
-          "java.io.InputStream",
-          "java.lang.Deprecated",
-          "java.io.Writer",
-          "java.io.OutputStream",
-          "java.util.List",
-          "java.util.Collection",
-          "java.lang.instrument.IllegalClassFormatException",
-          "javax.transaction.xa.XAException",
-          "java.lang.annotation.Repeatable",
-          "java.lang.InterruptedException",
-          "java.lang.CloneNotSupportedException",
-          "java.lang.Throwable",
-          "java.lang.Thread",
-          "java.lang.Enum"
-  };
-
 
   @Override
   protected String[] createTestArguments(String packageListFile, String mapFile,
@@ -123,11 +103,7 @@ public class SigTestDriver extends SignatureTestDriver {
       command.add(subPackages[i]);
     }
 
-    for(String jdkClassName:excludeJdkClasses) {
-      command.add(EXCLUDE_JDK_CLASS_FLAG);
-      command.add(jdkClassName);
-    }
-
+    command.add(EXCLUDE_JDK_CLASS_FLAG);
 
     command.add(API_VERSION_FLAG);
     command.add(info.getVersion());

--- a/tck/tck-runtime/src/main/java/servlet/tck/spec/defaultmapping/DefaultMappingTests.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/spec/defaultmapping/DefaultMappingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,6 +21,12 @@
 package servlet.tck.spec.defaultmapping;
 
 import servlet.tck.common.client.AbstractTckTest;
+import servlet.tck.spec.requestmap.TestServlet1;
+import servlet.tck.spec.requestmap.TestServlet2;
+import servlet.tck.spec.requestmap.TestServlet3;
+import servlet.tck.spec.requestmap.TestServlet4;
+import servlet.tck.spec.requestmap.TestServlet5;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -34,7 +40,8 @@ public class DefaultMappingTests extends AbstractTckTest {
   @Deployment(testable = false)
   public static WebArchive getTestArchive() throws Exception {
     return ShrinkWrap.create(WebArchive.class, "servlet_spec_defaultmapping_web.war")
-            .addClasses(TestServlet6.class)
+            .addClasses(TestServlet1.class, TestServlet2.class, TestServlet3.class, TestServlet4.class,
+                    TestServlet5.class, TestServlet6.class)
             .setWebXML(DefaultMappingTests.class.getResource("servlet_spec_defaultmapping_web.xml"));
   }
 

--- a/tck/tck-runtime/src/main/java/servlet/tck/spec/httpservletresponse/HttpServletResponseTests.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/spec/httpservletresponse/HttpServletResponseTests.java
@@ -70,19 +70,55 @@ public class HttpServletResponseTests extends AbstractTckTest {
   }
 
   /*
-   * @testName: flushBufferTest
+   * @testName: flushBufferOnContentLengthTest
    *
    * @assertion_ids: Servlet:SPEC:32; Servlet:SPEC:33; Servlet:SPEC:42.2;
    *
    * @test_Strategy: 1. First call setContentLength to set the length of
-   * content; 2. Then write to the buffer to fill up the buffer. 2. Call
-   * setIntHeader to set header 3. Verify that the header value is not set,
+   * content; 2. Write bytes to the expected content length; 3. Call
+   * setIntHeader to set header; 4. Attempt to write
+   * additional bytes, expecting an exception to confirm the output stream
+   * is closed; 5. Verify a 200 response without the header value set.
+   * 6. Repeat the test to check that the expected exception was thrown
+   * after the first request.
    */
   @Test
-  public void flushBufferTest() throws Exception {
+  public void flushBufferOnContentLengthTest() throws Exception {
+    TEST_PROPS.get().setProperty(SAVE_STATE, "true");
     TEST_PROPS.get().setProperty(UNEXPECTED_HEADERS, "header1: 12345");
     TEST_PROPS.get().setProperty(REQUEST, "GET " + getContextRoot() + "/"
-        + getServletName() + "?testname=" + "flushBufferTest" + " HTTP/1.1");
+        + getServletName() + "?testname=" + "flushBufferOnContentLengthTest" + " HTTP/1.1");
+    invoke();
+
+    TEST_PROPS.get().setProperty(USE_SAVED_STATE, "true");
+    TEST_PROPS.get().setProperty(UNEXPECTED_HEADERS, "header1: 12345");
+    TEST_PROPS.get().setProperty(REQUEST, "GET " + getContextRoot() + "/"
+        + getServletName() + "?testname=" + "flushBufferOnContentLengthTest" + " HTTP/1.1");
+    invoke();
+  }
+
+  /*
+   * @testName: flushBufferOnContentLengthCommittedTest
+   *
+   * @assertion_ids: Servlet:SPEC:32; Servlet:SPEC:33; Servlet:SPEC:42.2;
+   *
+   * @test_Strategy: 1. First call setContentLength to set the length of
+   * content; 2. Write some bytes and flush the response; 3. Write
+   * remaining bytes to the expected content length; 4. Attempt to write
+   * additional bytes, expecting an exception to confirm the output stream
+   * is closed; 5. Verify a 200 response; 6. Repeat the test to check that
+   * the expected exception was thrown after the first request.
+   */
+  @Test
+  public void flushBufferOnContentLengthCommittedTest() throws Exception {
+    TEST_PROPS.get().setProperty(SAVE_STATE, "true");
+    TEST_PROPS.get().setProperty(REQUEST, "GET " + getContextRoot() + "/"
+        + getServletName() + "?testname=" + "flushBufferOnContentLengthCommittedTest" + " HTTP/1.1");
+    invoke();
+
+    TEST_PROPS.get().setProperty(USE_SAVED_STATE, "true");
+    TEST_PROPS.get().setProperty(REQUEST, "GET " + getContextRoot() + "/"
+        + getServletName() + "?testname=" + "flushBufferOnContentLengthCommittedTest" + " HTTP/1.1");
     invoke();
   }
 

--- a/tck/tck-runtime/src/main/java/servlet/tck/spec/httpservletresponse/HttpServletResponseTests.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/spec/httpservletresponse/HttpServletResponseTests.java
@@ -70,55 +70,19 @@ public class HttpServletResponseTests extends AbstractTckTest {
   }
 
   /*
-   * @testName: flushBufferOnContentLengthTest
+   * @testName: flushBufferTest
    *
    * @assertion_ids: Servlet:SPEC:32; Servlet:SPEC:33; Servlet:SPEC:42.2;
    *
    * @test_Strategy: 1. First call setContentLength to set the length of
-   * content; 2. Write bytes to the expected content length; 3. Call
-   * setIntHeader to set header; 4. Attempt to write
-   * additional bytes, expecting an exception to confirm the output stream
-   * is closed; 5. Verify a 200 response without the header value set.
-   * 6. Repeat the test to check that the expected exception was thrown
-   * after the first request.
+   * content; 2. Then write to the buffer to fill up the buffer. 2. Call
+   * setIntHeader to set header 3. Verify that the header value is not set,
    */
   @Test
-  public void flushBufferOnContentLengthTest() throws Exception {
-    TEST_PROPS.get().setProperty(SAVE_STATE, "true");
+  public void flushBufferTest() throws Exception {
     TEST_PROPS.get().setProperty(UNEXPECTED_HEADERS, "header1: 12345");
     TEST_PROPS.get().setProperty(REQUEST, "GET " + getContextRoot() + "/"
-        + getServletName() + "?testname=" + "flushBufferOnContentLengthTest" + " HTTP/1.1");
-    invoke();
-
-    TEST_PROPS.get().setProperty(USE_SAVED_STATE, "true");
-    TEST_PROPS.get().setProperty(UNEXPECTED_HEADERS, "header1: 12345");
-    TEST_PROPS.get().setProperty(REQUEST, "GET " + getContextRoot() + "/"
-        + getServletName() + "?testname=" + "flushBufferOnContentLengthTest" + " HTTP/1.1");
-    invoke();
-  }
-
-  /*
-   * @testName: flushBufferOnContentLengthCommittedTest
-   *
-   * @assertion_ids: Servlet:SPEC:32; Servlet:SPEC:33; Servlet:SPEC:42.2;
-   *
-   * @test_Strategy: 1. First call setContentLength to set the length of
-   * content; 2. Write some bytes and flush the response; 3. Write
-   * remaining bytes to the expected content length; 4. Attempt to write
-   * additional bytes, expecting an exception to confirm the output stream
-   * is closed; 5. Verify a 200 response; 6. Repeat the test to check that
-   * the expected exception was thrown after the first request.
-   */
-  @Test
-  public void flushBufferOnContentLengthCommittedTest() throws Exception {
-    TEST_PROPS.get().setProperty(SAVE_STATE, "true");
-    TEST_PROPS.get().setProperty(REQUEST, "GET " + getContextRoot() + "/"
-        + getServletName() + "?testname=" + "flushBufferOnContentLengthCommittedTest" + " HTTP/1.1");
-    invoke();
-
-    TEST_PROPS.get().setProperty(USE_SAVED_STATE, "true");
-    TEST_PROPS.get().setProperty(REQUEST, "GET " + getContextRoot() + "/"
-        + getServletName() + "?testname=" + "flushBufferOnContentLengthCommittedTest" + " HTTP/1.1");
+        + getServletName() + "?testname=" + "flushBufferTest" + " HTTP/1.1");
     invoke();
   }
 

--- a/tck/tck-runtime/src/main/java/servlet/tck/spec/httpservletresponse/HttpServletResponseTests.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/spec/httpservletresponse/HttpServletResponseTests.java
@@ -78,7 +78,7 @@ public class HttpServletResponseTests extends AbstractTckTest {
    * content; 2. Then write to the buffer to fill up the buffer. 2. Call
    * setIntHeader to set header 3. Verify that the header value is not set,
    */
-  @Test
+  @Ignore @Test
   public void flushBufferTest() throws Exception {
     TEST_PROPS.get().setProperty(UNEXPECTED_HEADERS, "header1: 12345");
     TEST_PROPS.get().setProperty(REQUEST, "GET " + getContextRoot() + "/"

--- a/tck/tck-runtime/src/main/java/servlet/tck/spec/httpservletresponse/HttpTestServlet.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/spec/httpservletresponse/HttpTestServlet.java
@@ -25,12 +25,8 @@
 package servlet.tck.spec.httpservletresponse;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
-import jakarta.servlet.http.HttpSession;
 import servlet.tck.common.servlets.HttpTCKServlet;
 
 import jakarta.servlet.ServletException;
@@ -46,54 +42,22 @@ public class HttpTestServlet extends HttpTCKServlet {
     response.addIntHeader("header2", 56789);
   }
 
-  public void flushBufferOnContentLengthTest(HttpServletRequest request,
+  public void flushBufferTest(HttpServletRequest request,
       HttpServletResponse response) throws ServletException, IOException {
-    HttpSession session = request.getSession(true);
-    Object illegalStateException = session.getAttribute("IllegalStateException");
-    if (illegalStateException instanceof IllegalStateException)
-      throw (IllegalStateException)illegalStateException;
-
     int size = 40;
     response.setContentLength(size);
 
-    OutputStream out = response.getOutputStream();
-    byte[] passed = "Test PASSED\n".getBytes(StandardCharsets.ISO_8859_1);
-    out.write(passed);
+    PrintWriter pw = response.getWriter();
+    pw.println("Test PASSED");
+    StringBuffer tmp = new StringBuffer(2 * size);
+    int i = 0;
 
-    byte[] fill = new byte[size - passed.length];
-    Arrays.fill(fill, (byte) 'x');
-    out.write(fill);
+    while (i < 8) {
+      tmp = tmp.append("111111111x");
+      i = i + 1;
+    }
+    pw.println(tmp);
     response.addIntHeader("header1", 12345);
-
-    try {
-      out.write(fill);
-      session.setAttribute("IllegalStateException", new IllegalStateException("write did not fail"));
-    } catch (IOException ignored) {}
-  }
-
-  public void flushBufferOnContentLengthCommittedTest(HttpServletRequest request,
-      HttpServletResponse response) throws ServletException, IOException {
-    HttpSession session = request.getSession(true);
-    Object illegalStateException = session.getAttribute("IllegalStateException");
-    if (illegalStateException instanceof IllegalStateException)
-        throw (IllegalStateException)illegalStateException;
-
-    int size = 40;
-    response.setContentLength(size);
-
-    OutputStream out = response.getOutputStream();
-    byte[] passed = "Test PASSED\n".getBytes(StandardCharsets.ISO_8859_1);
-    out.write(passed);
-    response.flushBuffer();
-
-    byte[] fill = new byte[size - passed.length];
-    Arrays.fill(fill, (byte) 'x');
-    out.write(fill);
-
-    try {
-      out.write(fill);
-      session.setAttribute("IllegalStateException", new IllegalStateException("write did not fail"));
-    } catch (IOException ignored) {}
   }
 
   public void sendErrorCommitTest(HttpServletRequest request,

--- a/tck/tck-runtime/src/main/java/servlet/tck/spec/httpservletresponse/HttpTestServlet.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/spec/httpservletresponse/HttpTestServlet.java
@@ -25,8 +25,12 @@
 package servlet.tck.spec.httpservletresponse;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
+import jakarta.servlet.http.HttpSession;
 import servlet.tck.common.servlets.HttpTCKServlet;
 
 import jakarta.servlet.ServletException;
@@ -42,22 +46,54 @@ public class HttpTestServlet extends HttpTCKServlet {
     response.addIntHeader("header2", 56789);
   }
 
-  public void flushBufferTest(HttpServletRequest request,
+  public void flushBufferOnContentLengthTest(HttpServletRequest request,
       HttpServletResponse response) throws ServletException, IOException {
+    HttpSession session = request.getSession(true);
+    Object illegalStateException = session.getAttribute("IllegalStateException");
+    if (illegalStateException instanceof IllegalStateException)
+      throw (IllegalStateException)illegalStateException;
+
     int size = 40;
     response.setContentLength(size);
 
-    PrintWriter pw = response.getWriter();
-    pw.println("Test PASSED");
-    StringBuffer tmp = new StringBuffer(2 * size);
-    int i = 0;
+    OutputStream out = response.getOutputStream();
+    byte[] passed = "Test PASSED\n".getBytes(StandardCharsets.ISO_8859_1);
+    out.write(passed);
 
-    while (i < 8) {
-      tmp = tmp.append("111111111x");
-      i = i + 1;
-    }
-    pw.println(tmp);
+    byte[] fill = new byte[size - passed.length];
+    Arrays.fill(fill, (byte) 'x');
+    out.write(fill);
     response.addIntHeader("header1", 12345);
+
+    try {
+      out.write(fill);
+      session.setAttribute("IllegalStateException", new IllegalStateException("write did not fail"));
+    } catch (IOException ignored) {}
+  }
+
+  public void flushBufferOnContentLengthCommittedTest(HttpServletRequest request,
+      HttpServletResponse response) throws ServletException, IOException {
+    HttpSession session = request.getSession(true);
+    Object illegalStateException = session.getAttribute("IllegalStateException");
+    if (illegalStateException instanceof IllegalStateException)
+        throw (IllegalStateException)illegalStateException;
+
+    int size = 40;
+    response.setContentLength(size);
+
+    OutputStream out = response.getOutputStream();
+    byte[] passed = "Test PASSED\n".getBytes(StandardCharsets.ISO_8859_1);
+    out.write(passed);
+    response.flushBuffer();
+
+    byte[] fill = new byte[size - passed.length];
+    Arrays.fill(fill, (byte) 'x');
+    out.write(fill);
+
+    try {
+      out.write(fill);
+      session.setAttribute("IllegalStateException", new IllegalStateException("write did not fail"));
+    } catch (IOException ignored) {}
   }
 
   public void sendErrorCommitTest(HttpServletRequest request,

--- a/tck/tck-runtime/src/main/resources/servlet/tck/signature/jakarta.servlet.sig_6.2
+++ b/tck/tck-runtime/src/main/resources/servlet/tck/signature/jakarta.servlet.sig_6.2
@@ -860,6 +860,7 @@ fld public final static int SC_BAD_REQUEST = 400
 fld public final static int SC_CONFLICT = 409
 fld public final static int SC_CONTINUE = 100
 fld public final static int SC_CREATED = 201
+fld public final static int SC_EARLY_HINTS = 103
 fld public final static int SC_EXPECTATION_FAILED = 417
 fld public final static int SC_FORBIDDEN = 403
 fld public final static int SC_FOUND = 302
@@ -911,6 +912,7 @@ meth public abstract void addCookie(jakarta.servlet.http.Cookie)
 meth public abstract void addDateHeader(java.lang.String,long)
 meth public abstract void addHeader(java.lang.String,java.lang.String)
 meth public abstract void addIntHeader(java.lang.String,int)
+meth public abstract void sendEarlyHints()
 meth public abstract void sendError(int) throws java.io.IOException
 meth public abstract void sendError(int,java.lang.String) throws java.io.IOException
 meth public abstract void sendRedirect(java.lang.String,int,boolean) throws java.io.IOException
@@ -939,6 +941,7 @@ meth public void addCookie(jakarta.servlet.http.Cookie)
 meth public void addDateHeader(java.lang.String,long)
 meth public void addHeader(java.lang.String,java.lang.String)
 meth public void addIntHeader(java.lang.String,int)
+meth public void sendEarlyHints()
 meth public void sendError(int) throws java.io.IOException
 meth public void sendError(int,java.lang.String) throws java.io.IOException
 meth public void sendRedirect(java.lang.String) throws java.io.IOException

--- a/tck/tck-runtime/src/main/resources/servlet/tck/signature/jakarta.servlet.sig_6.2
+++ b/tck/tck-runtime/src/main/resources/servlet/tck/signature/jakarta.servlet.sig_6.2
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 6.1
+#Version 6.2
 
 CLSS public abstract interface jakarta.servlet.AsyncContext
 fld public final static java.lang.String ASYNC_CONTEXT_PATH = "jakarta.servlet.async.context_path"

--- a/tck/tck-runtime/src/main/resources/servlet/tck/signature/sig-test.map
+++ b/tck/tck-runtime/src/main/resources/servlet/tck/signature/sig-test.map
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2021 Oracle and/or its affiliates and others.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates and others.
 # All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -16,10 +16,10 @@
 #
 
 ###############################################################
-# The signature test mapping file for the JSF TCK.  This file
-# should be formatted as a standard java properties file.  The
-# name is the package name and the value is the version of the
-# package that should be tested by the signature tests.
+# The signature test mapping file for the Servlet TCK.  This
+# file should be formatted as a standard java properties file.
+# The name is the package name and the value is the version of
+# the package that should be tested by the signature tests.
 ###############################################################
 
 jakarta.servlet=6.2

--- a/tck/tck-runtime/src/main/resources/servlet/tck/signature/sig-test.map
+++ b/tck/tck-runtime/src/main/resources/servlet/tck/signature/sig-test.map
@@ -22,4 +22,4 @@
 # package that should be tested by the signature tests.
 ###############################################################
 
-jakarta.servlet=6.1
+jakarta.servlet=6.2

--- a/tck/tck-util/pom.xml
+++ b/tck/tck-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>servlet-tck</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>servlet-tck-util</artifactId>

--- a/tck/tck-util/pom.xml
+++ b/tck/tck-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>servlet-tck</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>servlet-tck-util</artifactId>


### PR DESCRIPTION
Reverts jakartaee/servlet#680

Hi,

The change in PR 680 has completely removed the old test, which has been around in many releases, and replaced with two new tests.  If the community thinks that the previous/old test is invalid, it should be excluded in the Servlet TCK 6.1.1.  Any new or replacement tests need to be added to the next servlet release.

PR 680 doesn’t follow the service release policy and needs to be reverted.