### PR TITLE
Fix #7 - clarify welcome files and filter mapping

### DIFF
--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -5666,9 +5666,14 @@ mapped to that request URI. If no match is found, the web server MUST
 again append each welcome file in the order specified in the deployment
 descriptor to the partial request and check if a servlet is mapped to
 that request URI. The web container must send the request to the first
-resource in the WAR that matches. The container may send the request to
-the welcome resource with a forward, a redirect, or a container specific
-mechanism that is indistinguishable from a direct request.
+resource in the WAR that matches.
+
+If a matching welcome file is found in the manner described, the container may
+send the request to the welcome resource with a forward, a redirect, or a
+container specific mechanism that is indistinguishable from a direct request. In
+later case, the request information (e.g. `getRequestURI()`) presented to the
+filter chain and the servlet will include the welcome file since filter mapping
+occurs after welcome file mapping.
 
 If no matching welcome file is found in the
 manner described, the container may handle the request in a manner it
@@ -8584,9 +8589,12 @@ Jakarta Servlet {spec-version} specification developed under the Jakarta EE Work
 
 === Changes Since Jakarta Servlet 6.1
 
+link:https://github.com/jakartaee/servlet/issues/7[Issue 7]::
+Clarify that welcome files are processed before filter mapping occurs.
+
 link:https://github.com/jakartaee/servlet/issues/542[Issue 542]::
 Add support for RFC 8297 (Early Hints) via a new method `sendEarlyHints()` on
-the `HttpServletResponse` 
+the `HttpServletResponse`.
 
 Clarify the description of when and how segments are re-encoded as part of URI Path Canonicalization.
 


### PR DESCRIPTION
This should be uncontroversial as it essentially documents the view of the Servlet EG since Servlet 3.0 times.