### PR TITLE
Fix #864 - re-enable specialchars substitution

### DIFF
--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -7720,7 +7720,7 @@ of the definitions listed in the deployment descriptor schema.
 
 .Basic Deployment Descriptor Example
 
-[source,xml,subs="attributes"]
+[source,xml,subs="attributes,specialchars"]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
@@ -7777,7 +7777,7 @@ of the definitions listed in the deployment descriptor schema.
 ==== An Example of Security
 
 .Deployment Descriptor Example Using Security
-[source,xml,subs="attributes"]
+[source,xml,subs="attributes,specialchars"]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
 


### PR DESCRIPTION
Manually enabling the attributes substitution disabled the default specialchars substitution which needed to be explicitly re-enabled.