### PR TITLE
Update JDK required to build spec

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -59,8 +59,8 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.8.0,)</version>
-                                    <message>You need JDK8 or higher</message>
+                                    <version>[11,)</version>
+                                    <message>You need JDK11 or higher</message>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
Just for consistency as using 1.8 causes:
```
[ERROR] org.apache.maven.plugin.PluginContainerException: Unable to load the mojo 'process-asciidoc' in the plugin 'org.asciidoctor:asciidoctor-maven-plugin:3.2.0' due to an API incompatibility: org.codehaus.plexus.component.repository.exception.ComponentLookupException: org/asciidoctor/maven/AsciidoctorMojo has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```

Which is hard to get anyway as after 52077a28 using 1.8 causes in first place:
```
Unrecognized option: --add-opens
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```