### PR TITLE
6.1.x fix junit warning

### DIFF
--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/httpservletrequest40/HttpServletRequest40Tests.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/httpservletrequest40/HttpServletRequest40Tests.java
@@ -177,8 +177,7 @@ public class HttpServletRequest40Tests extends AbstractTckTest {
             getContextRoot() + "/DispatchServlet", "GET",
             "matchValue=TestServlet, pattern=/TestServlet, servletName=TestServlet, mappingMatch=EXACT");
   }
-
-  @Test
+  
   private void simpleTest(String testName, String request, String method,
       String expected) throws Exception {
     try {


### PR DESCRIPTION
- Remove @Test annotation from non test method to avoid junit warning

Very trivial change