### PR TITLE
Remove @test annotation from non test method to avoid junit warning

### DIFF
--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/httpservletrequest40/HttpServletRequest40Tests.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/httpservletrequest40/HttpServletRequest40Tests.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -178,7 +179,6 @@ public class HttpServletRequest40Tests extends AbstractTckTest {
             "matchValue=TestServlet, pattern=/TestServlet, servletName=TestServlet, mappingMatch=EXACT");
   }
 
-  @Test
   private void simpleTest(String testName, String request, String method,
       String expected) throws Exception {
     try {


### PR DESCRIPTION
Port of @olamy's fix from 6.1.x