### PR TITLE
Fix issue 681

### DIFF
--- a/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/sessioncookieconfig/TestServlet.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/api/jakarta_servlet_http/sessioncookieconfig/TestServlet.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -12,10 +13,6 @@
  * https://www.gnu.org/software/classpath/license.html.
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
- */
-
-/*
- * $Id$
  */
 package servlet.tck.api.jakarta_servlet_http.sessioncookieconfig;
 
@@ -31,6 +28,8 @@ import jakarta.servlet.http.HttpSession;
 
 public class TestServlet extends HttpTCKServlet {
 
+  private static final long serialVersionUID = 1L;
+
   public void constructortest1(HttpServletRequest request,
       HttpServletResponse response) throws IOException {
     request.getSession(true);
@@ -39,7 +38,7 @@ public class TestServlet extends HttpTCKServlet {
 
     if (results.indexOf("-FAILED-") > -1) {
       ServletTestUtil.printResult(
-          response.getWriter(), "At least on test failed.  " + results);
+          response.getWriter(), "At least one test failed.  " + results);
     }
 
   }
@@ -64,6 +63,7 @@ public class TestServlet extends HttpTCKServlet {
     }
   }
 
+  @SuppressWarnings("removal")
   public void setCommentTest(HttpServletRequest request,
       HttpServletResponse response) throws IOException {
     String comment = "WHO_SHOULD_NOT_BE_NAMED_HERE";

--- a/tck/tck-runtime/src/main/java/servlet/tck/webxml/api/jakarta_servlet_http/sessioncookieconfig/SessionCookieConfigTests.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/webxml/api/jakarta_servlet_http/sessioncookieconfig/SessionCookieConfigTests.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2012, 2025 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package servlet.tck.webxml.api.jakarta_servlet_http.sessioncookieconfig;
+
+import servlet.tck.common.client.AbstractTckTest;
+import servlet.tck.common.servlets.CommonServlets;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SessionCookieConfigTests extends AbstractTckTest {
+
+    @BeforeEach
+    public void setupServletName() throws Exception {
+        setServletName("TestServlet");
+    }
+
+    /**
+     * Deployment for the test
+     *
+     * @return The WAR to deploy
+     *
+     * @throws Exception if deployment fails
+     */
+    @Deployment(testable = false)
+    public static WebArchive getTestArchive() throws Exception {
+        return ShrinkWrap.create(WebArchive.class, "servlet_xjsh_sessioncookieconfig_web.war")
+                .addAsLibraries(CommonServlets.getCommonServletsArchive())
+                .addClasses(TestListener.class, TestServlet.class)
+                .setWebXML(SessionCookieConfigTests.class.getResource("servlet_xjsh_sessioncookieconfig_web.xml"));
+    }
+
+
+    /*
+     * @class.setup_props: webServerHost; webServerPort; ts_home;
+     */
+    /* Run test */
+    /*
+     * @testName: constructortest1
+     *
+     * @test_Strategy: Create a Servlet TestServlet; In the Servlet, turn HttpSession on;
+     * In ServletContextListener, create a SessionCookieConfig instance, Verify in Client that the SessionCookieConfig
+     * instance is created, and all SessionCookieConfig APIs work accordingly.
+     */
+    @Test
+    public void constructortest1() throws Exception {
+        TEST_PROPS.get().setProperty(REQUEST,
+                "GET " + getContextRoot() + "/TestServlet?testname=constructortest1 HTTP/1.1");
+        TEST_PROPS.get().setProperty(EXPECTED_HEADERS, "Set-Cookie:" + "TCK_Cookie_Name=" + "##Expires=" + "##Path=" +
+                getContextRoot() + "/TestServlet" + "##Secure");
+        invoke();
+    }
+
+    /*
+     * @testName: setNameTest
+     *
+     * @assertion_ids: Servlet:JAVADOC:744;
+     *
+     * @test_Strategy: Create a Servlet TestServlet, In the Servlet, turn HttpSession on; Verify in servlet
+     * SessionCookieConfig.setName cannot be called once is set.
+     */
+    @Test
+    public void setNameTest() throws Exception {
+        TEST_PROPS.get().setProperty(APITEST, "setNameTest");
+        invoke();
+    }
+
+    /*
+     * @testName: setCommentTest
+     *
+     * @assertion_ids: Servlet:JAVADOC:740;
+     *
+     * @test_Strategy: Create a Servlet TestServlet, In the Servlet, turn HttpSession on; Verify in servlet
+     * SessionCookieConfig.setComment cannot be called once is set.
+     */
+    @Test
+    public void setCommentTest() throws Exception {
+        TEST_PROPS.get().setProperty(APITEST, "setCommentTest");
+        invoke();
+    }
+
+    /*
+     * @testName: setPathTest
+     *
+     * @assertion_ids: Servlet:JAVADOC:745;
+     *
+     * @test_Strategy: Create a Servlet TestServlet, In the Servlet, turn HttpSession on; Verify in servlet
+     * SessionCookieConfig.setPath cannot be called once is set.
+     */
+    @Test
+    public void setPathTest() throws Exception {
+        TEST_PROPS.get().setProperty(APITEST, "setPathTest");
+        invoke();
+    }
+
+    /*
+     * @testName: setDomainTest
+     *
+     * @assertion_ids: Servlet:JAVADOC:741;
+     *
+     * @test_Strategy: Create a Servlet TestServlet, In the Servlet, turn HttpSession on; Verify in servlet
+     * SessionCookieConfig.setDomain cannot be called once is set.
+     */
+    @Test
+    public void setDomainTest() throws Exception {
+        TEST_PROPS.get().setProperty(APITEST, "setDomainTest");
+        invoke();
+    }
+
+    /*
+     * @testName: setMaxAgeTest
+     *
+     * @assertion_ids: Servlet:JAVADOC:743;
+     *
+     * @test_Strategy: Create a Servlet TestServlet, In the Servlet, turn HttpSession on; Verify in servlet
+     * SessionCookieConfig.setMaxAge cannot be called once is set.
+     */
+    @Test
+    public void setMaxAgeTest() throws Exception {
+        TEST_PROPS.get().setProperty(APITEST, "setMaxAgeTest");
+        invoke();
+    }
+
+    /*
+     * @testName: setHttpOnlyTest
+     *
+     * @assertion_ids: Servlet:JAVADOC:742;
+     *
+     * @test_Strategy: Create a Servlet TestServlet, In the Servlet, turn HttpSession on; Verify in servlet
+     * SessionCookieConfig.setHttpOnly cannot be called once is set.
+     */
+    @Test
+    public void setHttpOnlyTest() throws Exception {
+        TEST_PROPS.get().setProperty(APITEST, "setHttpOnlyTest");
+        invoke();
+    }
+
+    /*
+     * @testName: setSecureTest
+     *
+     * @assertion_ids: Servlet:JAVADOC:746;
+     *
+     * @test_Strategy: Create a Servlet TestServlet, In the Servlet, turn HttpSession on; Verify in servlet
+     * SessionCookieConfig.setSecure cannot be called once is set.
+     */
+    @Test
+    public void setSecureTest() throws Exception {
+        TEST_PROPS.get().setProperty(APITEST, "setSecureTest");
+        invoke();
+    }
+
+    /*
+     * @testName: setAttributeTest
+     *
+     * @assertion_ids:
+     *
+     * @test_Strategy: Create a Servlet TestServlet, In the Servlet, turn HttpSession on; Verify in servlet
+     * SessionCookieConfig.setAttribute cannot be called once is set.
+     */
+    @Test
+    public void setAttributeTest() throws Exception {
+        TEST_PROPS.get().setProperty(APITEST, "setAttributeTest");
+        invoke();
+    }
+}

--- a/tck/tck-runtime/src/main/java/servlet/tck/webxml/api/jakarta_servlet_http/sessioncookieconfig/TestListener.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/webxml/api/jakarta_servlet_http/sessioncookieconfig/TestListener.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2009, 2025 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package servlet.tck.webxml.api.jakarta_servlet_http.sessioncookieconfig;
+
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.SessionCookieConfig;
+
+public class TestListener implements ServletContextListener {
+
+    /**
+     * Test for SessionCookieConfig configured via web.xml.
+     */
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        StringBuffer testData = new StringBuffer("Testing_Session_Cookie_Config");
+        String domain = "sun.com";
+        String path = sce.getServletContext().getContextPath() + "/TestServlet";
+        boolean isSecure = true;
+        boolean httpOnly = false;
+        int maxage = 50000;
+        String attrName = "a1";
+        String attrValue = "b2";
+        String name = "TCK_Cookie_Name";
+
+        SessionCookieConfig scf = sce.getServletContext().getSessionCookieConfig();
+
+        if (!scf.getPath().equals(path)) {
+            testData.append("|getPath-FAILED-expecting-" + path + "-got-" + scf.getPath());
+        }
+
+        if (!scf.isSecure()) {
+            testData.append("|isSecure-FAILED-expecting-" + isSecure + "-got-" + scf.isSecure());
+        }
+
+        if (scf.isHttpOnly()) {
+            testData.append("|isHttpOnly-FAILED-expecting-" + httpOnly + "-got-" + scf.isHttpOnly());
+        }
+
+        if (!scf.getDomain().equals(domain)) {
+            testData.append("|getDomain-FAILED-expecting-" + domain + "-got-" + scf.getDomain());
+        }
+
+        if (scf.getMaxAge() != maxage) {
+            testData.append("|getMaxAge-FAILED-expecting-" + maxage + "-got-" + scf.getMaxAge());
+        }
+
+        if (!scf.getAttribute(attrName).equals(attrValue)) {
+            testData.append("|getAttribute-FAILED-expecting-" + attrValue + "-got-" + scf.getAttribute(attrName));
+        }
+
+        if (!scf.getName().equals(name)) {
+            testData.append("|getName-FAILED-expecting-" + name + "-got-" + scf.getName());
+        }
+
+        sce.getServletContext().setAttribute(this.getClass().getName(), testData.toString());
+    }
+}

--- a/tck/tck-runtime/src/main/java/servlet/tck/webxml/api/jakarta_servlet_http/sessioncookieconfig/TestServlet.java
+++ b/tck/tck-runtime/src/main/java/servlet/tck/webxml/api/jakarta_servlet_http/sessioncookieconfig/TestServlet.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2009, 2025 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package servlet.tck.webxml.api.jakarta_servlet_http.sessioncookieconfig;
+
+import java.io.IOException;
+import servlet.tck.common.util.ServletTestUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class TestServlet extends servlet.tck.api.jakarta_servlet_http.sessioncookieconfig.TestServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void constructortest1(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        request.getSession(true);
+
+        String results = (String) getServletContext().getAttribute(TestListener.class.getName());
+
+        if (results.indexOf("-FAILED-") > -1) {
+            ServletTestUtil.printResult(response.getWriter(), "At least one test failed.  " + results);
+        }
+
+    }
+}

--- a/tck/tck-runtime/src/main/java/servlet/tck/webxml/api/jakarta_servlet_http/sessioncookieconfig/servlet_xjsh_sessioncookieconfig_web.xml
+++ b/tck/tck-runtime/src/main/java/servlet/tck/webxml/api/jakarta_servlet_http/sessioncookieconfig/servlet_xjsh_sessioncookieconfig_web.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2025 Oracle and/or its affiliates and others.
+    All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                             https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
+    <listener>
+        <listener-class>servlet.tck.webxml.api.jakarta_servlet_http.sessioncookieconfig.TestListener</listener-class>
+    </listener>
+    <servlet>
+        <servlet-name>TestLogicalName</servlet-name>
+        <servlet-class>servlet.tck.webxml.api.jakarta_servlet_http.sessioncookieconfig.TestServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>TestLogicalName</servlet-name>
+        <url-pattern>/TestServlet</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>54</session-timeout>
+        <cookie-config>
+          <name>TCK_Cookie_Name</name>
+          <domain>sun.com</domain>
+          <path>/servlet_xjsh_sessioncookieconfig_web/TestServlet</path>
+          <secure>true</secure>
+          <http-only>false</http-only>
+          <max-age>50000</max-age>
+          <attribute>
+            <attribute-name>a1</attribute-name>
+            <attribute-value>b2</attribute-value>
+          </attribute>
+        </cookie-config>
+    </session-config>
+</web-app>


### PR DESCRIPTION
This fixes #681. 

It adds some new test cases for web.xml configuration of SessionCookieConfig based on the programmatic tests.

I've built the TCK locally and confirmed that the newly added tests pass when run with the latest Tomcat 12.0.x code.

I'm not expecting this to be controversial so I'm intending to merge this shortly.