### PR TITLE
Clarify when complete and dispatch throw an ISE

### DIFF
--- a/api/src/main/java/jakarta/servlet/AsyncContext.java
+++ b/api/src/main/java/jakarta/servlet/AsyncContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2025 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -200,8 +200,9 @@ public interface AsyncContext {
      * within the same asynchronous cycle will result in an IllegalStateException. If startAsync is subsequently called on
      * the dispatched request, then any of the dispatch or {@link #complete} methods may be called.
      *
-     * @throws IllegalStateException if one of the dispatch methods has been called and the startAsync method has not been
-     * called during the resulting dispatch, or if {@link #complete} was called
+     * @throws IllegalStateException if, for the current request, one of the {@code startAsync} methods has not been called,
+     * one of the {@code dispatch} methods has been called and a {@code startAsync} method has not been called during the
+     * resulting dispatch, or if {@link #complete()} has been called
      *
      * @see ServletRequest#getDispatcherType
      */
@@ -233,8 +234,9 @@ public interface AsyncContext {
      * @param path the path of the dispatch target, scoped to the ServletContext from which this AsyncContext was
      * initialized
      *
-     * @throws IllegalStateException if one of the dispatch methods has been called and the startAsync method has not been
-     * called during the resulting dispatch, or if {@link #complete} was called
+     * @throws IllegalStateException if, for the current request, one of the {@code startAsync} methods has not been called,
+     * one of the {@code dispatch} methods has been called and a {@code startAsync} method has not been called during the
+     * resulting dispatch, or if {@link #complete()} has been called
      *
      * @see ServletRequest#getDispatcherType
      */
@@ -267,8 +269,9 @@ public interface AsyncContext {
      * @param context the ServletContext of the dispatch target
      * @param path the path of the dispatch target, scoped to the given ServletContext
      *
-     * @throws IllegalStateException if one of the dispatch methods has been called and the startAsync method has not been
-     * called during the resulting dispatch, or if {@link #complete} was called
+     * @throws IllegalStateException if, for the current request, one of the {@code startAsync} methods has not been called,
+     * one of the {@code dispatch} methods has been called and a {@code startAsync} method has not been called during the
+     * resulting dispatch, or if {@link #complete()} has been called
      *
      * @see ServletRequest#getDispatcherType
      */
@@ -302,6 +305,10 @@ public interface AsyncContext {
      * described by {@code ServletOutputStream#close} and this call to complete will not take effect (and any invocations of
      * {@link AsyncListener#onComplete(AsyncEvent)} will be delayed) until after any in progress non-blocking write has
      * completed.
+     *
+     * @throws IllegalStateException if, for the current request, one of the {@code startAsync} methods has not been called,
+     * one of the {@code dispatch} methods has been called and a {@code startAsync} method has not been called during the
+     * resulting dispatch, or if {@link #complete()} has been called
      */
     void complete();
 

--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -8589,6 +8589,9 @@ link:https://github.com/jakartaee/servlet/issues/867[Issue 867]::
 When processing the `If-Modified-Since` header in `HttpServerlet.service()`,
 invalid header values must be ignored as per RFC 9110.
 
+Clarify the Javadoc for when the `AsyncContext` `complete()` and `dispatch()`
+methods throw an `IllegalStateException`. 
+
 === Changes Since Jakarta Servlet 6.0
 
 link:https://github.com/eclipse-ee4j/servlet-api/issues/59[Issue 59]::


### PR DESCRIPTION
This is intended only to align the Javadoc description of when an ISE is thrown with the text in the spec doc.

I'll leave this for at least a week in case others read the spec document differently.