### PR TITLE
6.1.x Use servlet api release to cut a tck release to Maven central

### DIFF
--- a/tck/tck-runtime/pom.xml
+++ b/tck/tck-runtime/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <shrinkwrap-resolver.version>3.3.6</shrinkwrap-resolver.version>
-        <servlet.api.version>6.1.1-SNAPSHOT</servlet.api.version>
+        <servlet.api.version>6.1.0</servlet.api.version>
         <sigtest.version>2.6</sigtest.version>
     </properties>
 


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
