### PR TITLE
Fix README headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Run the build:
 The build runs copyright check and generates the jar, sources-jar and javadoc-jar by default.
 The API jar is built in /api/target.
 
-## TCk Challenges
+## TCK Challenges
 
 All test challenges for Jakarta Servlet must be resolved by Active Resolution.
 Please see the TCK Users guide for more details.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ This repository contains the code for Jakarta Servlet.
 
 [Online JavaDoc](https://javadoc.io/doc/jakarta.servlet/jakarta.servlet-api/)
 
-About Jakarta Servlet
----------------------
+## About Jakarta Servlet
+
 Jakarta Servlet defines a server-side API for handling HTTP requests and responses.
 
-Building
---------
+## Building
+
 Prerequisites:
 
 * JDK 17+


### PR DESCRIPTION
- Corrected a typo in the heading (`TCk` → `TCK`)
- Corrected the heading style (standardized to `#`)